### PR TITLE
feat: make uvx init install toolkit assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Reusable toolkit for running parallel AI agents with git worktrees and tmux. It 
 gh repo clone laris-co/multi-agent-workflow-kit
 cd multi-agent-workflow-kit
 
-# One-shot bootstrap (runs setup + tmux launch)
+# One-shot bootstrap (installs toolkit assets, setup, and tmux launch)
 uvx --from git+https://github.com/laris-co/multi-agent-workflow-kit.git \
   multi-agent-kit init --prefix demo
 
@@ -40,7 +40,7 @@ uvx --from git+https://github.com/laris-co/multi-agent-workflow-kit.git \
   multi-agent-kit init --prefix hackathon --detach
 ```
 
-Use `--setup-only` to prepare worktrees without starting tmux.
+Use `--setup-only` to prepare worktrees without starting tmux. The first run copies `.agents/` and `.tmux.conf` into the current repository; pass `--force-assets` to overwrite those files if you need to refresh them.
 
 ## Prerequisites
 | Tool | Purpose |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,10 @@ multi-agent-kit = "multi_agent_kit.cli:main"
 
 [tool.setuptools]
 package-dir = {"" = "src"}
+include-package-data = true
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.setuptools.package-data]
+"multi_agent_kit" = ["assets/**"]

--- a/src/multi_agent_kit/assets/.agents/README.md
+++ b/src/multi_agent_kit/assets/.agents/README.md
@@ -14,7 +14,7 @@ This directory ships with everything required to spin up dedicated git worktrees
 gh repo clone laris-co/multi-agent-workflow-kit
 cd multi-agent-workflow-kit
 
-# Optional: run the uvx bootstrap (installs toolkit assets, setup + tmux launch)
+# Optional: run the uvx bootstrap (setup + tmux launch)
 uvx --from git+https://github.com/laris-co/multi-agent-workflow-kit.git multi-agent-kit init
 
 # Customize agent registry

--- a/src/multi_agent_kit/assets/.agents/agents.sh
+++ b/src/multi_agent_kit/assets/.agents/agents.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+REGISTRY="$SCRIPT_DIR/agents.yaml"
+cmd=${1:-}
+
+need() { command -v "$1" >/dev/null 2>&1 || { echo "Error: missing dependency '$1'" >&2; exit 1; }; }
+
+read_yaml() {
+  need yq
+  yq "$1" "$REGISTRY"
+}
+
+create() {
+  local agent=${1:?usage: $0 create <agent>}
+  local branch path abs_path
+  branch=$(read_yaml ".agents.$agent.branch")
+  path=$(read_yaml ".agents.$agent.worktree_path")
+
+  case "$path" in
+    .agents/agents/*) : ;;
+    *) echo "Error: worktree_path '$path' must start with .agents/agents/" >&2; exit 1;;
+  esac
+
+  abs_path="$REPO_ROOT/$path"
+
+  git -C "$REPO_ROOT" branch "$branch" 2>/dev/null || true
+  mkdir -p "$(dirname "$abs_path")"
+
+  if [ -d "$abs_path" ]; then
+    echo "ℹ️  Agent already exists at $path"
+  else
+    git -C "$REPO_ROOT" worktree add "$abs_path" "$branch"
+    echo "✅ Created $agent worktree at $path on branch $branch"
+  fi
+}
+
+list() {
+  echo "📋 Git worktrees:"
+  git -C "$REPO_ROOT" worktree list
+  echo ""
+  echo "📤 Agents under .agents/agents/:"
+  for d in "$SCRIPT_DIR"/agents/*; do
+    if [ -d "$d" ]; then
+      local branch
+      branch=$(git -C "$d" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "?")
+      printf "  %s [%s]\n" "${d#$REPO_ROOT/}" "$branch"
+    fi
+  done
+}
+
+remove() {
+  local agent=${1:?usage: $0 remove <agent>}
+  local path abs_path
+  path=$(read_yaml ".agents.$agent.worktree_path")
+  abs_path="$REPO_ROOT/$path"
+
+  if [ -d "$abs_path" ] && git -C "$REPO_ROOT" worktree list | grep -q "$abs_path"; then
+    git -C "$REPO_ROOT" worktree remove "$abs_path" --force 2>/dev/null || true
+    echo "✅ Removed worktree at $path"
+  else
+    echo "ℹ️  No worktree to remove at $path"
+  fi
+}
+
+case "$cmd" in
+  create) create "${2-}" ;;
+  list)   list ;;
+  remove) remove "${2-}" ;;
+  *) echo "Usage: $0 {create|list|remove} [agent]" ;;
+esac

--- a/src/multi_agent_kit/assets/.agents/agents.yaml
+++ b/src/multi_agent_kit/assets/.agents/agents.yaml
@@ -1,0 +1,8 @@
+# Define each agent's branch and worktree location here.
+# Copy this file to match your team structure; run `.agents/setup.sh` afterward.
+agents:
+  example-agent:
+    branch: agents/example-agent
+    worktree_path: .agents/agents/example-agent
+    model: codex
+    description: Replace this with the agent's role or responsibilities

--- a/src/multi_agent_kit/assets/.agents/kill-all.sh
+++ b/src/multi_agent_kit/assets/.agents/kill-all.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Kill all tmux sessions created by start-agents.sh
+
+set -e
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+CUSTOM_PREFIX=""
+SESSION_PREFIX_OVERRIDE=""
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --prefix)
+            CUSTOM_PREFIX="$2"
+            shift 2
+            ;;
+        --session-prefix)
+            SESSION_PREFIX_OVERRIDE="$2"
+            shift 2
+            ;;
+        *)
+            echo "Usage: $0 [--prefix <suffix>] [--session-prefix <base>]"
+            exit 1
+            ;;
+    esac
+done
+
+BASE_PREFIX=${SESSION_PREFIX_OVERRIDE:-${SESSION_PREFIX:-ai}}
+DIR_NAME=$(basename "$REPO_ROOT")
+
+if [ -n "$CUSTOM_PREFIX" ]; then
+    SESSION_PATTERN="${BASE_PREFIX}-${DIR_NAME}-${CUSTOM_PREFIX}"
+else
+    SESSION_PATTERN="${BASE_PREFIX}-${DIR_NAME}"
+fi
+
+SESSIONS=$(tmux list-sessions -F "#{session_name}" 2>/dev/null | grep "^${SESSION_PATTERN}" || true)
+
+if [ -z "$SESSIONS" ]; then
+    echo "ℹ️  No sessions found matching: ${SESSION_PATTERN}*"
+    exit 0
+fi
+
+echo "🔍 Found sessions:"
+echo "$SESSIONS"
+echo ""
+read -p "❓ Kill all these sessions? (y/N): " -n 1 -r
+echo
+
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+    echo "$SESSIONS" | while read -r session; do
+        [ -z "$session" ] && continue
+        echo "🗑️  Killing session: $session"
+        tmux kill-session -t "$session"
+    done
+    echo "✅ All sessions killed"
+else
+    echo "❌ Cancelled"
+fi

--- a/src/multi_agent_kit/assets/.agents/profiles/profile1.sh
+++ b/src/multi_agent_kit/assets/.agents/profiles/profile1.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Profile 1: Left side full height, right side split into 3 panes
+# Left pane: full height
+# Right side: 3 panes stacked vertically (60%, 20%, 20%)
+
+# Layout configuration
+RIGHT_WIDTH=30           # Right column width percentage (left will be 70%)
+TOP_RIGHT_HEIGHT=40      # Bottom 2 panes combined (40% of right side, leaving top at 60%)
+MIDDLE_RIGHT_HEIGHT=50   # Middle pane height (50% of the bottom section = 20% of total)
+
+# Special layout flag
+LAYOUT_TYPE="full-left"  # Left side is one full pane
+
+# This profile is sourced by start-agents.sh

--- a/src/multi_agent_kit/assets/.agents/profiles/profile2.sh
+++ b/src/multi_agent_kit/assets/.agents/profiles/profile2.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Profile 2: 2x2 grid layout
+# Top row: 2 panes side by side
+# Bottom row: 2 panes side by side
+
+# Layout configuration
+RIGHT_WIDTH=30        # Right column width percentage
+TOP_RIGHT_HEIGHT=90   # Top-right pane height percentage
+BOTTOM_HEIGHT=30      # Bottom row height percentage
+
+# This profile is sourced by start-agents.sh

--- a/src/multi_agent_kit/assets/.agents/profiles/profile3.sh
+++ b/src/multi_agent_kit/assets/.agents/profiles/profile3.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Profile 3: 3 panes layout
+# Top: 1 full-width pane
+# Bottom: 2 panes side-by-side (50/50 split)
+
+# Layout configuration
+BOTTOM_HEIGHT=30         # Bottom row height percentage
+BOTTOM_RIGHT_WIDTH=50    # Bottom-right pane width (50/50 split)
+
+# Special layout flag
+LAYOUT_TYPE="top-full"   # Top pane is full width
+
+# This profile is sourced by start-agents.sh

--- a/src/multi_agent_kit/assets/.agents/profiles/profile4.sh
+++ b/src/multi_agent_kit/assets/.agents/profiles/profile4.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Profile 4: Like profile1 but only 3 panes (no bottom-right)
+# Left column: 70% width, split top/bottom
+# Right column: 30% width, one full pane
+
+# Layout configuration
+RIGHT_WIDTH=30           # Right column width percentage
+TOP_RIGHT_HEIGHT=100     # Top-right pane full height
+BOTTOM_HEIGHT=30         # Bottom-left pane height percentage
+
+# Special layout flag
+LAYOUT_TYPE="three-pane" # 3 panes only
+
+# This profile is sourced by start-agents.sh

--- a/src/multi_agent_kit/assets/.agents/profiles/profile5.sh
+++ b/src/multi_agent_kit/assets/.agents/profiles/profile5.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Profile 5: 6-pane layout
+# Pane 1 (top-left): root
+# Panes 2-5: 4 agent directories
+# Pane 6 (bottom-right): root
+
+RIGHT_WIDTH=50           # Right column width (%)
+TOP_RIGHT_HEIGHT=66      # Top-right pane height (%)
+BOTTOM_HEIGHT=50         # Bottom row height (%)
+BOTTOM_RIGHT_WIDTH=50    # Bottom-right split width (%)
+LAYOUT_TYPE="six-pane"

--- a/src/multi_agent_kit/assets/.agents/send-commands.sh
+++ b/src/multi_agent_kit/assets/.agents/send-commands.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# Send commands to existing tmux panes
+
+set -e
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+CUSTOM_PREFIX=""
+SESSION_OVERRIDE=""
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --prefix)
+            CUSTOM_PREFIX="$2"
+            shift 2
+            ;;
+        --session)
+            SESSION_OVERRIDE="$2"
+            shift 2
+            ;;
+        *)
+            echo "Usage: $0 [--prefix <name>] [--session <session-name>]"
+            exit 1
+            ;;
+    esac
+done
+
+BASE_PREFIX=${SESSION_PREFIX:-ai}
+DIR_NAME=$(basename "$REPO_ROOT")
+
+if [ -n "$SESSION_OVERRIDE" ]; then
+    SESSION_NAME="$SESSION_OVERRIDE"
+elif [ -n "$CUSTOM_PREFIX" ]; then
+    SESSION_NAME="${BASE_PREFIX}-${DIR_NAME}-${CUSTOM_PREFIX}"
+else
+    SESSION_NAME="${BASE_PREFIX}-${DIR_NAME}"
+fi
+
+if ! tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
+    echo "Error: Session '$SESSION_NAME' not found"
+    echo "Run .agents/start-agents.sh first to create the session"
+    exit 1
+fi
+
+PANE_COMMANDS=(
+    "pwd"
+    "pwd"
+    "pwd"
+    "pwd"
+    "pwd"
+    "pwd"
+)
+
+WINDOW_INDEX=$(tmux list-windows -t "$SESSION_NAME" -F "#{window_index}" | head -1)
+
+echo "Sending commands to tmux panes in $SESSION_NAME..."
+PANE_INDEX=1
+for cmd in "${PANE_COMMANDS[@]}"; do
+    if [ -n "$cmd" ]; then
+        echo "  Pane $PANE_INDEX: $cmd"
+        tmux send-keys -t "$SESSION_NAME":${WINDOW_INDEX}.$PANE_INDEX "$cmd" C-m
+        PANE_INDEX=$((PANE_INDEX + 1))
+    fi
+done
+
+echo "✅ Commands sent successfully"

--- a/src/multi_agent_kit/assets/.agents/setup.sh
+++ b/src/multi_agent_kit/assets/.agents/setup.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Setup script: Creates all agents and installs tmux plugins
+# Usage: .agents/setup.sh
+
+set -e
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+AGENTS_YAML="$SCRIPT_DIR/agents.yaml"
+TPM_DIR="$HOME/.tmux/plugins/tpm"
+
+# ========================================
+# Check direnv
+# ========================================
+echo "🔧 Checking direnv..."
+if ! command -v direnv &> /dev/null; then
+    echo "⚠️  direnv not found. Install it for automatic .tmux.conf loading:"
+    echo "   brew install direnv  # or your package manager"
+    echo ""
+else
+    echo "✅ direnv installed"
+if [ -f "$REPO_ROOT/.envrc" ]; then
+        echo "💡 Run 'direnv allow' to enable project config auto-loading"
+    fi
+fi
+echo ""
+
+# ========================================
+# Install TPM and tmux-power if needed
+# ========================================
+echo "🎨 Checking tmux plugin manager (TPM)..."
+if [ ! -d "$TPM_DIR" ]; then
+    echo "📥 Installing TPM..."
+    git clone https://github.com/tmux-plugins/tpm "$TPM_DIR"
+    echo "✅ TPM installed"
+else
+    echo "✅ TPM already installed"
+fi
+
+# Install plugins (reads from local .tmux.conf via TMUX_CONF env var)
+echo "📦 Installing tmux plugins (including tmux-power)..."
+# Start tmux server and set TMUX_PLUGIN_MANAGER_PATH globally
+tmux start-server 2>/dev/null || true
+tmux set-environment -g TMUX_PLUGIN_MANAGER_PATH "$HOME/.tmux/plugins/" 2>/dev/null || true
+tmux source-file "$REPO_ROOT/.tmux.conf" 2>/dev/null || true
+TMUX_CONF="$REPO_ROOT/.tmux.conf" "$TPM_DIR/bin/install_plugins" 2>/dev/null || echo "⚠️  Plugin installation skipped (will auto-install in tmux session)"
+echo "✅ Tmux plugins configured"
+echo ""
+
+# ========================================
+# Create agent worktrees
+# ========================================
+if [ ! -f "$AGENTS_YAML" ]; then
+    echo "❌ Error: $AGENTS_YAML not found"
+    exit 1
+fi
+
+echo "🚀 Setting up all agents from agents.yaml..."
+echo ""
+
+# Get list of all agent names
+AGENTS=$(yq e '.agents | keys | .[]' "$AGENTS_YAML")
+
+if [ -z "$AGENTS" ]; then
+    echo "❌ No agents found in agents.yaml"
+    exit 1
+fi
+
+# Create each agent
+for agent in $AGENTS; do
+    echo "📦 Creating agent: $agent"
+    "$SCRIPT_DIR/agents.sh" create "$agent"
+done
+
+echo ""
+echo "✅ All agents created successfully!"
+echo ""
+echo "📋 Current worktrees:"
+"$SCRIPT_DIR/agents.sh" list
+echo ""
+echo "💡 Tip: Restart tmux or run 'tmux source-file ~/.tmux.conf' to load plugins"

--- a/src/multi_agent_kit/assets/.agents/start-agents.sh
+++ b/src/multi_agent_kit/assets/.agents/start-agents.sh
@@ -1,0 +1,177 @@
+#!/bin/bash
+# Start multiple AI agents in tmux panes
+
+set -e
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+PROFILES_DIR="$SCRIPT_DIR/profiles"
+AGENTS_DIR="$SCRIPT_DIR/agents"
+
+CUSTOM_PREFIX=""
+PROFILE="profile1"
+DETACHED=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --prefix)
+            CUSTOM_PREFIX="$2"
+            shift 2
+            ;;
+        --detach|-d)
+            DETACHED=true
+            shift
+            ;;
+        *)
+            PROFILE="$1"
+            shift
+            ;;
+    esac
+done
+
+PROFILE_FILE="$PROFILES_DIR/${PROFILE}.sh"
+
+if [ -f "$PROFILE_FILE" ]; then
+    # shellcheck disable=SC1090
+    source "$PROFILE_FILE"
+    echo "📋 Using profile: $PROFILE"
+else
+    echo "⚠️  Profile '$PROFILE' not found, using defaults"
+    RIGHT_WIDTH=30
+    TOP_RIGHT_HEIGHT=90
+    BOTTOM_HEIGHT=30
+fi
+
+if [ ! -d "$AGENTS_DIR" ]; then
+    echo "Error: $AGENTS_DIR not found"
+    exit 1
+fi
+
+AGENTS=$(cd "$AGENTS_DIR" && ls -d */ 2>/dev/null | sed 's#/##' | tr '\n' ' ')
+
+if [ -z "$AGENTS" ]; then
+    echo "⚠️  No agent worktrees detected in $AGENTS_DIR"
+    echo "Run .agents/setup.sh or .agents/agents.sh create <name> first."
+    exit 1
+fi
+
+BASE_PREFIX=${SESSION_PREFIX:-ai}
+DIR_NAME=$(basename "$REPO_ROOT")
+
+if [ -n "$CUSTOM_PREFIX" ]; then
+    SESSION_NAME="${BASE_PREFIX}-${DIR_NAME}-${CUSTOM_PREFIX}"
+else
+    SESSION_NAME="${BASE_PREFIX}-${DIR_NAME}"
+    if tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
+        echo "❌ Error: Session '$SESSION_NAME' already exists"
+        echo "💡 Use --prefix <name> to create a separate session"
+        echo "   Example: .agents/start-agents.sh profile1 --prefix work"
+        exit 1
+    fi
+fi
+
+tmux kill-session -t "$SESSION_NAME" 2>/dev/null || true
+
+AGENTS_ARRAY=($AGENTS)
+TOTAL=${#AGENTS_ARRAY[@]}
+
+if [ "$LAYOUT_TYPE" = "six-pane" ]; then
+    echo "Starting session in root directory..."
+    tmux new-session -d -s "$SESSION_NAME" -c "$REPO_ROOT"
+else
+    echo "Starting session with ${AGENTS_ARRAY[0]}..."
+    tmux new-session -d -s "$SESSION_NAME" -c "$AGENTS_DIR/${AGENTS_ARRAY[0]}"
+fi
+
+if [ "$LAYOUT_TYPE" = "three-pane" ]; then
+    if [ $TOTAL -ge 2 ]; then
+        echo "Adding pane for ${AGENTS_ARRAY[1]}..."
+        tmux split-window -h -t "$SESSION_NAME" -c "$AGENTS_DIR/${AGENTS_ARRAY[1]}" -p "$RIGHT_WIDTH"
+    fi
+    if [ $TOTAL -ge 3 ]; then
+        echo "Adding pane for ${AGENTS_ARRAY[2]}..."
+        tmux select-pane -t "$SESSION_NAME":1.1
+        tmux split-window -v -t "$SESSION_NAME" -c "$AGENTS_DIR/${AGENTS_ARRAY[2]}" -p "${BOTTOM_HEIGHT:-30}"
+    fi
+elif [ "$LAYOUT_TYPE" = "top-full" ]; then
+    if [ $TOTAL -ge 2 ]; then
+        echo "Adding pane for ${AGENTS_ARRAY[1]}..."
+        tmux split-window -v -t "$SESSION_NAME" -c "$AGENTS_DIR/${AGENTS_ARRAY[1]}" -p "${BOTTOM_HEIGHT:-30}"
+    fi
+    if [ $TOTAL -ge 3 ]; then
+        echo "Adding pane for ${AGENTS_ARRAY[2]}..."
+        tmux split-window -h -t "$SESSION_NAME" -c "$AGENTS_DIR/${AGENTS_ARRAY[2]}" -p "${BOTTOM_RIGHT_WIDTH:-50}"
+    fi
+elif [ "$LAYOUT_TYPE" = "full-left" ]; then
+    echo "Adding pane 2 (top-right)..."
+    if [ $TOTAL -ge 2 ]; then
+        tmux split-window -h -t "$SESSION_NAME" -c "$AGENTS_DIR/${AGENTS_ARRAY[1]}" -p "$RIGHT_WIDTH"
+    else
+        tmux split-window -h -t "$SESSION_NAME" -p "$RIGHT_WIDTH"
+    fi
+
+    echo "Adding pane 3 (middle-right)..."
+    tmux select-pane -t "$SESSION_NAME":1.2
+    if [ $TOTAL -ge 3 ]; then
+        tmux split-window -v -t "$SESSION_NAME" -c "$AGENTS_DIR/${AGENTS_ARRAY[2]}" -p "$TOP_RIGHT_HEIGHT"
+    else
+        tmux split-window -v -t "$SESSION_NAME" -p "$TOP_RIGHT_HEIGHT"
+    fi
+
+    echo "Adding pane 4 (bottom-right)..."
+    if [ $TOTAL -ge 4 ]; then
+        tmux split-window -v -t "$SESSION_NAME" -c "$AGENTS_DIR/${AGENTS_ARRAY[3]}" -p "${MIDDLE_RIGHT_HEIGHT:-50}"
+    else
+        tmux split-window -v -t "$SESSION_NAME" -p "${MIDDLE_RIGHT_HEIGHT:-50}"
+    fi
+elif [ "$LAYOUT_TYPE" = "six-pane" ]; then
+    if [ $TOTAL -ge 1 ]; then
+        echo "Adding pane 2 for ${AGENTS_ARRAY[0]}..."
+        tmux split-window -h -t "$SESSION_NAME" -c "$AGENTS_DIR/${AGENTS_ARRAY[0]}" -p "$RIGHT_WIDTH"
+    fi
+    if [ $TOTAL -ge 2 ]; then
+        echo "Adding pane 3 for ${AGENTS_ARRAY[1]}..."
+        tmux select-pane -t "$SESSION_NAME":1.1
+        tmux split-window -v -t "$SESSION_NAME" -c "$AGENTS_DIR/${AGENTS_ARRAY[1]}" -p "$TOP_RIGHT_HEIGHT"
+    fi
+    if [ $TOTAL -ge 3 ]; then
+        echo "Adding pane 4 for ${AGENTS_ARRAY[2]}..."
+        tmux select-pane -t "$SESSION_NAME":1.2
+        tmux split-window -v -t "$SESSION_NAME" -c "$AGENTS_DIR/${AGENTS_ARRAY[2]}" -p "$TOP_RIGHT_HEIGHT"
+    fi
+    if [ $TOTAL -ge 4 ]; then
+        echo "Adding pane 5 for ${AGENTS_ARRAY[3]}..."
+        tmux select-pane -t "$SESSION_NAME":1.3
+        tmux split-window -v -t "$SESSION_NAME" -c "$AGENTS_DIR/${AGENTS_ARRAY[3]}"
+    fi
+    echo "Adding pane 6 (root)..."
+    tmux select-pane -t "$SESSION_NAME":1.4
+    tmux split-window -v -t "$SESSION_NAME" -c "$REPO_ROOT"
+else
+    if [ $TOTAL -ge 2 ]; then
+        echo "Adding pane for ${AGENTS_ARRAY[1]}..."
+        tmux split-window -h -t "$SESSION_NAME" -c "$AGENTS_DIR/${AGENTS_ARRAY[1]}" -p "$RIGHT_WIDTH"
+        tmux resize-pane -t "$SESSION_NAME":0.1 -y "${TOP_RIGHT_HEIGHT}%"
+    fi
+    if [ $TOTAL -ge 3 ]; then
+        echo "Adding pane for ${AGENTS_ARRAY[2]}..."
+        tmux select-pane -t "$SESSION_NAME":1.1
+        tmux split-window -v -t "$SESSION_NAME" -c "$AGENTS_DIR/${AGENTS_ARRAY[2]}" -p "${BOTTOM_HEIGHT:-30}"
+    fi
+    if [ $TOTAL -ge 4 ]; then
+        echo "Adding pane for ${AGENTS_ARRAY[3]}..."
+        tmux select-pane -t "$SESSION_NAME":1.2
+        tmux split-window -v -t "$SESSION_NAME" -c "$AGENTS_DIR/${AGENTS_ARRAY[3]}" -p "${BOTTOM_HEIGHT:-30}"
+    fi
+fi
+
+echo ""
+echo "✅ Started $TOTAL agents in tmux session: $SESSION_NAME"
+
+if [ "$DETACHED" = true ]; then
+    echo "📌 Running in detached mode"
+    echo "💡 Attach with: tmux attach-session -t $SESSION_NAME"
+else
+    echo "📍 Attaching to session..."
+    tmux attach-session -t "$SESSION_NAME"
+fi

--- a/src/multi_agent_kit/assets/.tmux.conf
+++ b/src/multi_agent_kit/assets/.tmux.conf
@@ -1,0 +1,46 @@
+# Multi-Agent Workflow Kit tmux configuration
+
+set -g mouse on
+bind -n MouseDown1Pane select-pane -t=
+bind -n WheelUpPane if-shell -F -t = "#{mouse_any_flag}" "send-keys -M" "if -Ft= '#{pane_in_mode}' 'send-keys -M' 'select-pane -t=; copy-mode -e; send-keys -M'"
+bind -n WheelDownPane select-pane -t= \; send-keys -M
+bind -n MouseDrag1Border resize-pane -M
+bind -n MouseDown1Status select-window -t=
+# Paste-selection shortcut
+bind -n MouseDown3Pane paste-buffer
+
+set -g default-terminal "screen-256color"
+set -ga terminal-overrides ",*256col*:Tc"
+
+set -g pane-active-border-style 'fg=colour39,bg=default'
+set -g pane-border-style 'fg=colour244,bg=default'
+set -g status-style 'bg=colour234 fg=colour39'
+set -g status-left '#[fg=colour16,bg=colour39,bold] #S #[fg=colour39,bg=colour234]'
+set -g status-right '#[fg=colour226,bg=colour234]#[fg=colour16,bg=colour226,bold] %d/%m #[fg=colour39]#[fg=colour16,bg=colour39,bold] %H:%M:%S '
+setw -g window-status-style 'fg=colour246 bg=colour234'
+setw -g window-status-current-style 'fg=colour16 bg=colour39 bold'
+setw -g window-status-format ' #I:#W#F '
+setw -g window-status-current-format ' #I:#W#F '
+
+setw -g mode-keys vi
+bind-key -T copy-mode-vi v send-keys -X begin-selection
+bind-key -T copy-mode-vi y send-keys -X copy-selection-and-cancel
+bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-selection-and-cancel
+
+set -g history-limit 10000
+set -sg escape-time 0
+set -g base-index 1
+setw -g pane-base-index 1
+bind r source-file ~/.tmux.conf \; display-message "Config reloaded!"
+
+# Set TPM environment variable
+set-environment -g TMUX_PLUGIN_MANAGER_PATH "$HOME/.tmux/plugins/"
+
+set -g @plugin 'tmux-plugins/tpm'
+set -g @plugin 'tmux-plugins/tmux-sensible'
+set -g @plugin 'wfxr/tmux-power'
+set -g @tmux_power_theme 'gold'
+set -g @tmux_power_show_upload_speed true
+set -g @tmux_power_show_download_speed true
+
+run '~/.tmux/plugins/tpm/tpm'

--- a/src/multi_agent_kit/install.py
+++ b/src/multi_agent_kit/install.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import shutil
+from importlib import resources as importlib_resources
+from importlib.abc import Traversable
+from pathlib import Path
+from typing import Iterator
+
+ASSET_PACKAGE = "multi_agent_kit"
+ASSET_ROOT_NAME = "assets"
+TOP_LEVEL_ITEMS = (".agents", ".tmux.conf")
+
+
+@dataclass(frozen=True)
+class CopyPlan:
+    source: Traversable
+    destination: Path
+
+
+class AssetInstaller:
+    def __init__(self, target: Path, force: bool = False) -> None:
+        self.target = target
+        self.force = force
+
+    def ensure_assets(self) -> list[Path]:
+        written: list[Path] = []
+        for name in TOP_LEVEL_ITEMS:
+            source = self._asset_root().joinpath(name)
+            destination = self.target / name
+            self._copy(source, destination, written)
+        return written
+
+    def _asset_root(self) -> Traversable:
+        return importlib_resources.files(ASSET_PACKAGE).joinpath(ASSET_ROOT_NAME)
+
+    def _copy(self, source: Traversable, destination: Path, written: list[Path]) -> None:
+        if source.is_dir():
+            destination.mkdir(parents=True, exist_ok=True)
+            for child in source.iterdir():
+                self._copy(child, destination / child.name, written)
+            return
+
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        if destination.exists() and not self.force:
+            return
+
+        with importlib_resources.as_file(source) as src_path:
+            shutil.copy2(src_path, destination)
+        written.append(destination)
+
+
+def missing_assets(target: Path) -> Iterator[str]:
+    for name in TOP_LEVEL_ITEMS:
+        if not (target / name).exists():
+            yield name

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from multi_agent_kit.install import AssetInstaller, missing_assets
+
+
+def test_installer_creates_assets(tmp_path: Path) -> None:
+    installer = AssetInstaller(tmp_path)
+    assert list(missing_assets(tmp_path)) == [".agents", ".tmux.conf"]
+
+    written = installer.ensure_assets()
+    assert (tmp_path / ".agents").is_dir()
+    assert (tmp_path / ".tmux.conf").is_file()
+    assert written  # some files were copied
+
+    # second run without force should not rewrite files
+    written_again = installer.ensure_assets()
+    assert written_again == []
+    assert list(missing_assets(tmp_path)) == []
+
+
+def test_force_overwrites(tmp_path: Path) -> None:
+    installer = AssetInstaller(tmp_path)
+    installer.ensure_assets()
+
+    target_conf = tmp_path / ".tmux.conf"
+    target_conf.write_text("user modified")
+
+    force_installer = AssetInstaller(tmp_path, force=True)
+    written = force_installer.ensure_assets()
+    assert target_conf.read_text() != "user modified"
+    assert target_conf.is_file()
+    assert written  # at least one file rewritten
+
+    # ensure missing_assets still empty
+    assert list(missing_assets(tmp_path)) == []


### PR DESCRIPTION
## Summary
- package the toolkit assets under `multi_agent_kit/assets` and include them in the wheel
- extend `multi-agent-kit init` to copy `.agents/` + `.tmux.conf` automatically (with `--force-assets` flag)
- add tests covering asset installation and refresh, plus doc updates for the new behaviour

## Testing
- PYTHONPATH=src python3 -m multi_agent_kit.cli init --setup-only
- PYTHONPATH=src python3 -m multi_agent_kit.cli init --skip-setup --detach --prefix external profile2
- PYTHONPATH=src uvx --from pytest pytest
- uvx --from git+https://github.com/laris-co/multi-agent-workflow-kit.git@feat/install-command multi-agent-kit init --setup-only (from 1x-data-flow-mind-grid)
