### PR TITLE
docs: document initial git commit requirement for agent setup

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -22,6 +22,10 @@ cp .agents/agents.yaml .agents/agents.local.yaml   # optional snapshot
 # Edit .agents/agents.yaml with your agent names / branches
 
 # Create worktrees and install tmux plugins
+# NOTE: git worktrees require at least one commit in the repository.
+#       On a fresh repo, the setup script exits early and prints the
+#       commands below so you can commit the toolkit assets first:
+#       git add .agents/ .tmux.conf && git commit -m "Initial toolkit commit"
 .agents/setup.sh
 
 # Launch tmux session (default layout = profile1)

--- a/.agents/setup.sh
+++ b/.agents/setup.sh
@@ -48,6 +48,17 @@ echo "✅ Tmux plugins configured"
 echo ""
 
 # ========================================
+# Ensure repository has an initial commit
+# ========================================
+if ! git -C "$REPO_ROOT" rev-parse --verify HEAD >/dev/null 2>&1; then
+    echo "ℹ️  This repository has no commits yet, so agent worktrees are skipped."
+    echo "💡 Create an initial commit then rerun .agents/setup.sh:"
+    echo "   git add .agents/ .tmux.conf"
+    echo "   git commit -m \"Initial commit: bootstrap multi-agent kit\""
+    exit 0
+fi
+
+# ========================================
 # Create agent worktrees
 # ========================================
 if [ ! -f "$AGENTS_YAML" ]; then

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ uvx --from git+https://github.com/laris-co/multi-agent-workflow-kit.git \
 $EDITOR .agents/agents.yaml
 
 # Provision worktrees + install tmux plugins (manual alternative)
+# Requires at least one commit in the repository. If none exist, the
+# setup script exits early and prints these commands for you to run:
+# git add .agents/ .tmux.conf && git commit -m "Initial toolkit commit"
 .agents/setup.sh
 
 # Launch the session manually (profile1 = balanced grid)


### PR DESCRIPTION
## Summary
- Documents the requirement for at least one git commit before running setup.sh
- Adds helpful error handling and user guidance
- Prevents the 'ambiguous argument HEAD' error for new repositories

## Changes
- Updated README.md with clear warning about initial commit requirement
- Enhanced setup.sh to check for commits and provide specific guidance
- Added documentation in .agents/README.md
- Provides exact commands to run if no commits exist

## Test Plan
- [ ] Run setup.sh in a repo with no commits - should show helpful message
- [ ] Run setup.sh in a repo with commits - should work normally
- [ ] Documentation is clear and helpful

Fixes #11

## Related
- Issue #11: Document requirement for initial git commit before agent setup