### PR TITLE
Warn when initializing agents on empty repos

### DIFF
--- a/src/multi_agent_kit/assets/agents/agents.sh
+++ b/src/multi_agent_kit/assets/agents/agents.sh
@@ -26,30 +26,25 @@ create() {
 
   abs_path="$REPO_ROOT/$path"
 
-  local branch_ref="refs/heads/$branch"
-  local has_head=1
-
   if ! git -C "$REPO_ROOT" rev-parse --verify HEAD >/dev/null 2>&1; then
-    has_head=0
+    cat <<'EOF'
+⚠️  The current repository has no commits yet.
+   Create an initial commit before running agent setup so Git worktrees have a base revision.
+   For example:
+     git commit --allow-empty -m "Initial commit"
+EOF
+    exit 1
   fi
 
+  git -C "$REPO_ROOT" branch "$branch" 2>/dev/null || true
   mkdir -p "$(dirname "$abs_path")"
 
   if [ -d "$abs_path" ]; then
     echo "ℹ️  Agent already exists at $path"
-    return
-  fi
-
-  # Reuse existing branch, create from the current HEAD, or start an orphan branch for brand-new repos
-  if git -C "$REPO_ROOT" show-ref --quiet "$branch_ref"; then
-    git -C "$REPO_ROOT" worktree add "$abs_path" "$branch"
-  elif [ "$has_head" -eq 1 ]; then
-    git -C "$REPO_ROOT" worktree add -b "$branch" "$abs_path"
   else
-    git -C "$REPO_ROOT" worktree add --orphan -b "$branch" "$abs_path"
+    git -C "$REPO_ROOT" worktree add "$abs_path" "$branch"
+    echo "✅ Created $agent worktree at $path on branch $branch"
   fi
-
-  echo "✅ Created $agent worktree at $path on branch $branch"
 }
 
 list() {

--- a/src/multi_agent_kit/assets/agents/agents.sh
+++ b/src/multi_agent_kit/assets/agents/agents.sh
@@ -36,7 +36,9 @@ EOF
     exit 1
   fi
 
-  git -C "$REPO_ROOT" branch "$branch" 2>/dev/null || true
+  if ! git -C "$REPO_ROOT" rev-parse --verify "$branch" >/dev/null 2>&1; then
+    git -C "$REPO_ROOT" branch "$branch"
+  fi
   mkdir -p "$(dirname "$abs_path")"
 
   if [ -d "$abs_path" ]; then


### PR DESCRIPTION
## Summary
- stop auto-creating orphan branches when the repository has no commits yet
- print a clear warning instructing the user to make an initial commit instead
- leave the existing worktree flow unchanged for repos with commits

## Testing
- (fails: pytest not available in environment)
