### PR TITLE
Ignore generated agent worktrees

### DIFF
--- a/src/multi_agent_kit/assets/agents/.gitignore
+++ b/src/multi_agent_kit/assets/agents/.gitignore
@@ -1,0 +1,2 @@
+# Ignore generated git worktrees for agents
+agents/


### PR DESCRIPTION
## Summary
- add a .gitignore inside the .agents asset directory so generated worktrees stay untracked

## Testing
- n/a (gitignore change)
