### PR TITLE
Move default agent worktrees to repo root

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -34,7 +34,7 @@ cp .agents/agents.yaml .agents/agents.local.yaml   # optional snapshot
 
 ## Common Commands
 ```bash
-.agents/agents.sh create 01-analyst      # create specific agent worktree
+.agents/agents.sh create 1-agent         # create specific agent worktree
 .agents/agents.sh list                   # list registered agents + branches
 .agents/start-agents.sh profile2         # launch tmux with alternate layout
 .agents/start-agents.sh profile1 --prefix work  # run a second session side-by-side
@@ -45,14 +45,14 @@ cp .agents/agents.yaml .agents/agents.local.yaml   # optional snapshot
 ## `agents.yaml` Format
 ```yaml
 agents:
-  01-analyst:
-    branch: agents/01-analyst
-    worktree_path: .agents/agents/01-analyst
-    model: claude
-    description: Primary research agent
+  1-agent:
+    branch: agents/1-agent
+    worktree_path: agents/1-agent
+    model: default
+    description: Primary agent workspace
 ```
 - `branch` will be created if it does not already exist.
-- `worktree_path` must live under `.agents/agents/` (guardrails enforced by the script).
+- `worktree_path` must live under `agents/` (legacy `.agents/agents/` is still accepted).
 - `model` and `description` are informational—use them to coordinate assignments.
 
 ## Layout Profiles
@@ -73,7 +73,7 @@ To add new layouts, copy an existing profile and adjust the environment variable
 ## Cleanup & Maintenance
 ```bash
 .agents/kill-all.sh                 # interactive kill for active sessions
-.agents/agents.sh remove 01-analyst # tear down a single worktree
+.agents/agents.sh remove 1-agent    # tear down a single worktree
 .git worktree prune                 # remove stale / deleted worktrees
 ```
 
@@ -92,7 +92,7 @@ To add new layouts, copy an existing profile and adjust the environment variable
 │   ├── profile3.sh
 │   ├── profile4.sh
 │   └── profile5.sh
-└── agents/                # actual worktrees (gitignored)
+agents/                    # actual worktrees (gitignored)
 ```
 
 ## Tips

--- a/.agents/agents.sh
+++ b/.agents/agents.sh
@@ -20,8 +20,8 @@ create() {
   path=$(read_yaml ".agents.$agent.worktree_path")
 
   case "$path" in
-    .agents/agents/*) : ;;
-    *) echo "Error: worktree_path '$path' must start with .agents/agents/" >&2; exit 1;;
+    agents/*|.agents/agents/*) : ;;
+    *) echo "Error: worktree_path '$path' must start with agents/ or .agents/agents/" >&2; exit 1;;
   esac
 
   abs_path="$REPO_ROOT/$path"
@@ -41,12 +41,24 @@ list() {
   echo "📋 Git worktrees:"
   git -C "$REPO_ROOT" worktree list
   echo ""
-  echo "📤 Agents under .agents/agents/:"
-  for d in "$SCRIPT_DIR"/agents/*; do
-    if [ -d "$d" ]; then
-      local branch
-      branch=$(git -C "$d" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "?")
-      printf "  %s [%s]\n" "${d#$REPO_ROOT/}" "$branch"
+  local bases=("$REPO_ROOT/agents" "$SCRIPT_DIR/agents")
+  for base in "${bases[@]}"; do
+    if [ -d "$base" ]; then
+      local label
+      if [[ "$base" == "$REPO_ROOT/agents" ]]; then
+        label="agents/"
+      else
+        label=".agents/agents/"
+      fi
+      echo "📤 Agents under $label"
+      for d in "$base"/*; do
+        if [ -d "$d" ]; then
+          local branch
+          branch=$(git -C "$d" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "?")
+          printf "  %s [%s]\n" "${d#$REPO_ROOT/}" "$branch"
+        fi
+      done
+      echo ""
     fi
   done
 }

--- a/.agents/agents.yaml
+++ b/.agents/agents.yaml
@@ -1,8 +1,18 @@
 # Define each agent's branch and worktree location here.
 # Copy this file to match your team structure; run `.agents/setup.sh` afterward.
 agents:
-  example-agent:
-    branch: agents/example-agent
-    worktree_path: .agents/agents/example-agent
-    model: codex
-    description: Replace this with the agent's role or responsibilities
+  1-agent:
+    branch: agents/1-agent
+    worktree_path: agents/1-agent
+    model: default
+    description: Primary agent workspace
+  2-agent:
+    branch: agents/2-agent
+    worktree_path: agents/2-agent
+    model: default
+    description: Secondary agent workspace
+  3-agent:
+    branch: agents/3-agent
+    worktree_path: agents/3-agent
+    model: default
+    description: Tertiary agent workspace

--- a/.agents/start-agents.sh
+++ b/.agents/start-agents.sh
@@ -6,7 +6,18 @@ set -e
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
 PROFILES_DIR="$SCRIPT_DIR/profiles"
-AGENTS_DIR="$SCRIPT_DIR/agents"
+DEFAULT_AGENTS_DIR="$REPO_ROOT/agents"
+LEGACY_AGENTS_DIR="$SCRIPT_DIR/agents"
+
+if [ -d "$DEFAULT_AGENTS_DIR" ]; then
+    AGENTS_DIR="$DEFAULT_AGENTS_DIR"
+else
+    AGENTS_DIR="$LEGACY_AGENTS_DIR"
+fi
+
+if [ "$AGENTS_DIR" = "$DEFAULT_AGENTS_DIR" ]; then
+    mkdir -p "$AGENTS_DIR"
+fi
 
 CUSTOM_PREFIX=""
 PROFILE="profile1"

--- a/README.md
+++ b/README.md
@@ -71,14 +71,14 @@ Use `--setup-only` to prepare worktrees without starting tmux. The first run cop
 │   ├── profile3.sh        # top-full layout
 │   ├── profile4.sh        # three-pane layout
 │   └── profile5.sh        # six-pane dashboard
-└── agents/                # populated worktrees (gitignored)
+agents/                    # repo-root worktrees (gitignored via agents/.gitignore)
 
 .tmux.conf                 # curated tmux config with TPM + power theme
 docs/                      # deep dives and checklists
 ```
 
 ## Operating Model
-1. Define each agent in `.agents/agents.yaml` (branch + worktree path).
+1. Define each agent in `.agents/agents.yaml` (branch + worktree path pointing into `agents/`).
 2. Run `.agents/setup.sh` after edits to sync worktrees and ensure dependencies.
 3. Start the tmux session with `.agents/start-agents.sh <profile> [--prefix <suffix>]`.
 4. Use `.agents/send-commands.sh` to broadcast helpful commands (`git status`, `ls`).

--- a/agents/.gitignore
+++ b/agents/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,14 +7,14 @@ The multi-agent workflow combines git worktrees with tmux so that each agent rec
 ```
 Main repository (.git)
     ├── source files
-    └── .agents/agents/
-          ├── 01-agent/ (worktree → branch agents/01-agent)
-          ├── 02-agent/ (worktree → branch agents/02-agent)
-          └── 03-agent/ (worktree → branch agents/03-agent)
+    └── agents/
+          ├── 1-agent/ (worktree → branch agents/1-agent)
+          ├── 2-agent/ (worktree → branch agents/2-agent)
+          └── 3-agent/ (worktree → branch agents/3-agent)
 
 .tmux session
-    ├── pane: agent 01 shell (cd .agents/agents/01-agent)
-    ├── pane: agent 02 shell (cd .agents/agents/02-agent)
+    ├── pane: agent 1 shell (cd agents/1-agent)
+    ├── pane: agent 2 shell (cd agents/2-agent)
     └── pane: shared tools / orchestration
 ```
 

--- a/src/multi_agent_kit/assets/agents/README.md
+++ b/src/multi_agent_kit/assets/agents/README.md
@@ -30,7 +30,7 @@ cp .agents/agents.yaml .agents/agents.local.yaml   # optional snapshot
 
 ## Common Commands
 ```bash
-.agents/agents.sh create 01-analyst      # create specific agent worktree
+.agents/agents.sh create 1-agent         # create specific agent worktree
 .agents/agents.sh list                   # list registered agents + branches
 .agents/start-agents.sh profile2         # launch tmux with alternate layout
 .agents/start-agents.sh profile1 --prefix work  # run a second session side-by-side
@@ -41,14 +41,14 @@ cp .agents/agents.yaml .agents/agents.local.yaml   # optional snapshot
 ## `agents.yaml` Format
 ```yaml
 agents:
-  01-analyst:
-    branch: agents/01-analyst
-    worktree_path: .agents/agents/01-analyst
-    model: claude
-    description: Primary research agent
+  1-agent:
+    branch: agents/1-agent
+    worktree_path: agents/1-agent
+    model: default
+    description: Primary agent workspace
 ```
 - `branch` will be created if it does not already exist.
-- `worktree_path` must live under `.agents/agents/` (guardrails enforced by the script).
+- `worktree_path` must live under `agents/` (legacy `.agents/agents/` is still accepted).
 - `model` and `description` are informational—use them to coordinate assignments.
 
 ## Layout Profiles
@@ -69,7 +69,7 @@ To add new layouts, copy an existing profile and adjust the environment variable
 ## Cleanup & Maintenance
 ```bash
 .agents/kill-all.sh                 # interactive kill for active sessions
-.agents/agents.sh remove 01-analyst # tear down a single worktree
+.agents/agents.sh remove 1-agent    # tear down a single worktree
 .git worktree prune                 # remove stale / deleted worktrees
 ```
 
@@ -88,7 +88,7 @@ To add new layouts, copy an existing profile and adjust the environment variable
 │   ├── profile3.sh
 │   ├── profile4.sh
 │   └── profile5.sh
-└── agents/                # actual worktrees (gitignored)
+agents/                    # actual worktrees (gitignored)
 ```
 
 ## Tips

--- a/src/multi_agent_kit/assets/agents/agents.sh
+++ b/src/multi_agent_kit/assets/agents/agents.sh
@@ -20,8 +20,8 @@ create() {
   path=$(read_yaml ".agents.$agent.worktree_path")
 
   case "$path" in
-    .agents/agents/*) : ;;
-    *) echo "Error: worktree_path '$path' must start with .agents/agents/" >&2; exit 1;;
+    agents/*|.agents/agents/*) : ;;
+    *) echo "Error: worktree_path '$path' must start with agents/ or .agents/agents/" >&2; exit 1;;
   esac
 
   abs_path="$REPO_ROOT/$path"
@@ -53,12 +53,24 @@ list() {
   echo "📋 Git worktrees:"
   git -C "$REPO_ROOT" worktree list
   echo ""
-  echo "📤 Agents under .agents/agents/:"
-  for d in "$SCRIPT_DIR"/agents/*; do
-    if [ -d "$d" ]; then
-      local branch
-      branch=$(git -C "$d" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "?")
-      printf "  %s [%s]\n" "${d#$REPO_ROOT/}" "$branch"
+  local bases=("$REPO_ROOT/agents" "$SCRIPT_DIR/agents")
+  for base in "${bases[@]}"; do
+    if [ -d "$base" ]; then
+      local label
+      if [[ "$base" == "$REPO_ROOT/agents" ]]; then
+        label="agents/"
+      else
+        label=".agents/agents/"
+      fi
+      echo "📤 Agents under $label"
+      for d in "$base"/*; do
+        if [ -d "$d" ]; then
+          local branch
+          branch=$(git -C "$d" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "?")
+          printf "  %s [%s]\n" "${d#$REPO_ROOT/}" "$branch"
+        fi
+      done
+      echo ""
     fi
   done
 }

--- a/src/multi_agent_kit/assets/agents/agents.yaml
+++ b/src/multi_agent_kit/assets/agents/agents.yaml
@@ -1,8 +1,18 @@
 # Define each agent's branch and worktree location here.
 # Copy this file to match your team structure; run `.agents/setup.sh` afterward.
 agents:
-  example-agent:
-    branch: agents/example-agent
-    worktree_path: .agents/agents/example-agent
-    model: codex
-    description: Replace this with the agent's role or responsibilities
+  1-agent:
+    branch: agents/1-agent
+    worktree_path: agents/1-agent
+    model: default
+    description: Primary agent workspace
+  2-agent:
+    branch: agents/2-agent
+    worktree_path: agents/2-agent
+    model: default
+    description: Secondary agent workspace
+  3-agent:
+    branch: agents/3-agent
+    worktree_path: agents/3-agent
+    model: default
+    description: Tertiary agent workspace

--- a/src/multi_agent_kit/assets/agents/start-agents.sh
+++ b/src/multi_agent_kit/assets/agents/start-agents.sh
@@ -6,7 +6,18 @@ set -e
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
 PROFILES_DIR="$SCRIPT_DIR/profiles"
-AGENTS_DIR="$SCRIPT_DIR/agents"
+DEFAULT_AGENTS_DIR="$REPO_ROOT/agents"
+LEGACY_AGENTS_DIR="$SCRIPT_DIR/agents"
+
+if [ -d "$DEFAULT_AGENTS_DIR" ]; then
+    AGENTS_DIR="$DEFAULT_AGENTS_DIR"
+else
+    AGENTS_DIR="$LEGACY_AGENTS_DIR"
+fi
+
+if [ "$AGENTS_DIR" = "$DEFAULT_AGENTS_DIR" ]; then
+    mkdir -p "$AGENTS_DIR"
+fi
 
 CUSTOM_PREFIX=""
 PROFILE="profile1"

--- a/src/multi_agent_kit/assets/agents_root/.gitignore
+++ b/src/multi_agent_kit/assets/agents_root/.gitignore
@@ -1,0 +1,3 @@
+# Ignore agent worktree checkouts placed at repo root
+*
+!.gitignore

--- a/src/multi_agent_kit/install.py
+++ b/src/multi_agent_kit/install.py
@@ -11,6 +11,7 @@ ASSET_PACKAGE = "multi_agent_kit"
 ASSET_ROOT_NAME = "assets"
 ITEM_MAP = (
     ("agents", ".agents"),
+    ("agents_root", "agents"),
     ("tmux.conf", ".tmux.conf"),
 )
 

--- a/start.sh
+++ b/start.sh
@@ -7,8 +7,19 @@
 #   ./start.sh profile5 --detach
 #   ./start.sh profile1 -d
 
-# Check if any agents exist, if not run setup
-if [ -z "$(git worktree list | grep '.agents/agents/')" ]; then
+# Check if any agents exist (supporting both legacy and new locations)
+ROOT_AGENTS_DIR="$(pwd)/agents"
+LEGACY_AGENTS_DIR="$(pwd)/.agents/agents"
+
+have_agents=false
+for dir in "$ROOT_AGENTS_DIR" "$LEGACY_AGENTS_DIR"; do
+    if [ -d "$dir" ] && [ -n "$(find "$dir" -mindepth 1 -maxdepth 1 -type d -print -quit 2>/dev/null)" ]; then
+        have_agents=true
+        break
+    fi
+done
+
+if [ "$have_agents" = false ]; then
     echo "🔧 No agents found. Running setup..."
     .agents/setup.sh
     echo ""

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -9,10 +9,12 @@ from multi_agent_kit.install import AssetInstaller, missing_assets
 
 def test_installer_creates_assets(tmp_path: Path) -> None:
     installer = AssetInstaller(tmp_path)
-    assert list(missing_assets(tmp_path)) == [".agents", ".tmux.conf"]
+    assert list(missing_assets(tmp_path)) == [".agents", "agents", ".tmux.conf"]
 
     written = installer.ensure_assets()
     assert (tmp_path / ".agents").is_dir()
+    assert (tmp_path / "agents").is_dir()
+    assert (tmp_path / "agents" / ".gitignore").is_file()
     assert (tmp_path / ".tmux.conf").is_file()
     assert written  # some files were copied
 


### PR DESCRIPTION
## Summary
- default to `agents/` at the repo root for agent worktrees with legacy fallback
- expand the starter registry to three agents (1/2/3) and sync docs/assets
- ship gitignore stubs and installer updates so new repos get the right layout

## Testing
- bash -n .agents/start-agents.sh
- bash -n .agents/agents.sh
- bash -n start.sh
- python -m pytest *(missing: pytest not installed in environment)*