### PR TITLE
feat: Add start.sh convenience script

### DIFF
--- a/src/multi_agent_kit/assets/start.sh
+++ b/src/multi_agent_kit/assets/start.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+
+# Simple wrapper for .agents/start-agents.sh
+# Default to profile1 if no arguments provided
+
+# Check if .agents exists
+if [ ! -d ".agents" ]; then
+    echo "❌ Toolkit not installed. Run: uvx multi-agent-kit init"
+    exit 1
+fi
+
+# Default to profile1 if no arguments
+if [ $# -eq 0 ]; then
+    exec .agents/start-agents.sh profile1
+else
+    exec .agents/start-agents.sh "$@"
+fi

--- a/src/multi_agent_kit/install.py
+++ b/src/multi_agent_kit/install.py
@@ -14,6 +14,7 @@ ITEM_MAP = (
     ("agents", "agents"),      # Gitignore-only directory for worktrees
     (".claude", ".claude"),    # Claude commands and configuration
     ("tmux.conf", ".tmux.conf"),
+    ("start.sh", "start.sh"),  # Convenience wrapper for start-agents.sh
 )
 
 


### PR DESCRIPTION
## Summary
Add a simple `start.sh` convenience script at the repository root to make launching agent sessions easier.

## Changes
- ✅ Add `start.sh` wrapper script to toolkit assets
- ✅ Update installer to include `start.sh` 
- ✅ Script defaults to profile1 if no arguments
- ✅ Passes all arguments through for flexibility

## Usage
```bash
# Simple start with default profile1
./start.sh

# Use specific profile
./start.sh profile2

# Pass any arguments
./start.sh profile1 --prefix dev --detach
```

## Benefits
- **Simpler command**: `./start.sh` vs `.agents/start-agents.sh profile1`
- **More discoverable**: Top-level script is obvious
- **Sensible default**: Uses profile1 automatically
- **Full flexibility**: All arguments passed through

## Testing
```bash
cd /tmp/test && git init
uvx --from . multi-agent-kit init --setup-only
ls -la start.sh  # Verify installed with executable permissions
./start.sh        # Test execution
```

Resolves #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)