### PR TITLE
Require initial commit before starting agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
 # Agent worktrees live under /agents and /.agents at repo root
 /.agents/
-.claude/.gitignore
-.claude/commands/catlab-*
 
 .tmux/resurrect/
 .tmux/plugins/

--- a/src/multi_agent_kit/assets/.agents/scripts/start-agents.sh
+++ b/src/multi_agent_kit/assets/.agents/scripts/start-agents.sh
@@ -66,6 +66,13 @@ if [ -z "$AGENTS" ]; then
     exit 1
 fi
 
+if ! git -C "$REPO_ROOT" rev-parse --verify HEAD >/dev/null 2>&1; then
+    echo "❌ Repository has no commits yet."
+    echo "   Create an initial commit before starting agents, for example:"
+    echo "   git commit --allow-empty -m \"Initial commit\""
+    exit 1
+fi
+
 BASE_PREFIX=${SESSION_PREFIX:-ai}
 DIR_NAME=$(basename "$REPO_ROOT")
 SESSION_EXISTS=false

--- a/src/multi_agent_kit/cli.py
+++ b/src/multi_agent_kit/cli.py
@@ -129,23 +129,19 @@ def maybe_commit_assets(root: Path, written: list[Path]) -> None:
     rel_paths = sorted({str(path.relative_to(root)) for path in written}) if written else []
 
     if not rel_paths:
-        # Nothing new installed; nothing to stage.
         return
 
     ignored_assets = detect_ignored_paths(root, rel_paths)
-    if ignored_assets:
-        print("ℹ️  Toolkit assets are ignored by .gitignore; leaving them unstaged.")
-        for path in ignored_assets:
-            print(f"   • {path}")
-        print("   Run 'git add -f' manually if you want them tracked.")
-        return
 
     print("ℹ️  Toolkit assets installed:")
     for path in rel_paths:
         print(f"   • {path}")
 
+    if ignored_assets:
+        print("   These files are normally ignored; staging will use 'git add -f'.")
+
     if prompt_yes_no("Commit these assets now? [y/N] "):
-        add_cmd = ["git", "add", "--", *rel_paths]
+        add_cmd = ["git", "add", "-f", "--", *rel_paths]
         add_proc = subprocess.run(add_cmd, cwd=root, check=False)
         if add_proc.returncode == 0:
             commit_cmd = [

--- a/src/multi_agent_kit/install.py
+++ b/src/multi_agent_kit/install.py
@@ -12,7 +12,7 @@ ASSET_ROOT_NAME = "assets"
 ITEM_MAP = (
     (".agents", ".agents"),    # Toolkit files go to .agents/
     ("agents", "agents"),      # Gitignore-only directory for worktrees
-    (".claude", ".claude"),    # Claude commands and configuration (ignored by default)
+    (".claude", ".claude"),    # Claude commands and configuration
     (".envrc", ".envrc"),  # direnv hook for tmux config
     ("AGENTS.md", "AGENTS.md"),  # Guide for human/AI collaborators
 )
@@ -46,7 +46,6 @@ class AssetInstaller:
                 destination = self.target / dest_name
                 self._copy(source, destination, written)
         self._ensure_root_gitignore(written)
-        self._ensure_claude_gitignore(written)
         return written
 
     def _asset_root(self) -> Traversable:
@@ -75,7 +74,7 @@ class AssetInstaller:
     def _ensure_root_gitignore(self, written: list[Path]) -> None:
         gitignore_path = self.target / ".gitignore"
         marker = "# Added by Multi-Agent Workflow Kit"
-        ignore_lines = ["/.agents/", ".claude/.gitignore", ".claude/commands/catlab-*"]
+        ignore_lines = ["/.agents/"]
 
         try:
             existing = gitignore_path.read_text()
@@ -87,10 +86,7 @@ class AssetInstaller:
 
         lines = [line.strip() for line in existing.splitlines()]
 
-        append_lines: list[str] = []
-        for entry in ignore_lines:
-            if entry not in lines:
-                append_lines.append(entry)
+        append_lines = [entry for entry in ignore_lines if entry not in lines]
 
         if not append_lines:
             return
@@ -103,27 +99,6 @@ class AssetInstaller:
         append_text += "\n".join(append_lines) + "\n"
 
         gitignore_path.write_text(existing + append_text)
-        written.append(gitignore_path)
-
-    def _ensure_claude_gitignore(self, written: list[Path]) -> None:
-        claude_dir = self.target / ".claude"
-        if not claude_dir.exists():
-            return
-
-        gitignore_path = claude_dir / ".gitignore"
-        desired = (
-            "# Ignore toolkit-provided Claude commands; customize by removing these entries\n"
-            "commands/catlab-agents-create.md\n"
-            "commands/catlab-codex.md\n"
-            "commands/catlab-codex.sh\n"
-            "commands/catlab-sync.md\n"
-            "commands/catlab-sync.sh\n"
-        )
-
-        if gitignore_path.exists() and gitignore_path.read_text() == desired:
-            return
-
-        gitignore_path.write_text(desired)
         written.append(gitignore_path)
 
 


### PR DESCRIPTION
## Summary
- bail out of  when the repository has no commits yet
- instruct the user to create an initial commit before launching tmux

## Testing
- ran  in a repo without commits (shows error and exits)
- ran  in a repo with commits (still launches)
