### PR TITLE
Export CODEX_HOME in .envrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -3,6 +3,11 @@
 toolkit_dir="$PWD/.agents"
 legacy_scripts_dir="$toolkit_dir/scripts"
 repo_root="$PWD"
+codex_dir="$PWD/.codex"
+
+if [[ -z "${CODEX_HOME:-}" && -d "$codex_dir" ]]; then
+  export CODEX_HOME="$codex_dir"
+fi
 
 declare -a maw_script_dirs=()
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ agents/                    # Agent worktrees (fully gitignored)
 │   └── catlab-sync.sh           # Shell helper implementing sync rules
 
 .agents/config/tmux.conf   # curated tmux config with TPM + power theme
+/.codex/ (optional)        # Codex CLI prompts and cache; .envrc sets CODEX_HOME if present
 docs/                      # deep dives and checklists
 ```
 

--- a/src/multi_agent_kit/assets/.envrc
+++ b/src/multi_agent_kit/assets/.envrc
@@ -1,6 +1,12 @@
 # shellcheck shell=bash
 
 scripts_dir="$PWD/.agents/scripts"
+codex_dir="$PWD/.codex"
+
+if [[ -z "${CODEX_HOME:-}" && -d "$codex_dir" ]]; then
+  export CODEX_HOME="$codex_dir"
+fi
+
 if [[ -d "$scripts_dir" ]]; then
   if command -v PATH_add >/dev/null 2>&1; then
     PATH_add "$scripts_dir"


### PR DESCRIPTION
## Summary
- set CODEX_HOME automatically in .envrc (and packaged .envrc) whenever a .codex directory exists
- mention the directory in README\'s repository layout so teams know where the cache lives

## Testing
- ran  in a repo with  and verified CODEX_HOME is exported
