### PR TITLE
Add direnv allow guidance for agent worktrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ agents/                    # Agent worktrees (fully gitignored)
 ├── 2-agent/               # Worktree for agent 2
 └── 3-agent/               # Worktree for agent 3
 
-.envrc                     # direnv hook adding script aliases and PATH entries
+.envrc                     # direnv hook adding script aliases and PATH entries (run `direnv allow` here and `direnv allow agents/*` inside worktrees)
 .claude/                   # Claude configuration (optional)
 ├── commands/              # Custom slash commands for Claude
 │   ├── maw-agents-create.md     # Agent creation command (/maw-agents-create)

--- a/src/multi_agent_kit/assets/.agents/scripts/setup.sh
+++ b/src/multi_agent_kit/assets/.agents/scripts/setup.sh
@@ -23,6 +23,7 @@ else
     echo "✅ direnv installed"
     if [ -f "$REPO_ROOT/.envrc" ]; then
         echo "💡 Run 'direnv allow' to enable project config auto-loading"
+        echo "   Tip: also run 'direnv allow agents/*' so each agent worktree trusts the env."
     fi
 fi
 echo ""


### PR DESCRIPTION
## Summary
- update setup.sh to remind users to run `direnv allow agents/*` after provisioning
- document the same tip in README next to the .envrc description

## Testing
- n/a (documentation output only)
