### PR TITLE
chore: ensure codex env override and gh auth reminder

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -5,7 +5,7 @@ legacy_scripts_dir="$toolkit_dir/scripts"
 repo_root="$PWD"
 codex_dir="$PWD/.codex"
 
-if [[ -z "${CODEX_HOME:-}" && -d "$codex_dir" ]]; then
+if [[ -d "$codex_dir" ]]; then
   export CODEX_HOME="$codex_dir"
 fi
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ Coordinate through normal GitHub pull requests: merge work from
 -   **⚠️ NEVER MERGE PULL REQUESTS WITHOUT EXPLICIT USER PERMISSION**
 -   **Never use `gh pr merge` unless explicitly instructed by the user**
 -   **Always wait for user review and approval before any merge**
+-   Before you go through the commit -> push -> PR flow, run `gh auth status` to confirm the GitHub CLI is connected; use `gh auth login` if it is not.
 
 ### File Operations
 -   Never use `rm -rf` - use `rm -i` for interactive confirmation.

--- a/src/multi_agent_kit/assets/AGENTS.md
+++ b/src/multi_agent_kit/assets/AGENTS.md
@@ -32,6 +32,7 @@ Coordinate through normal GitHub pull requests: merge work from
 -   **⚠️ NEVER MERGE PULL REQUESTS WITHOUT EXPLICIT USER PERMISSION**
 -   **Never use `gh pr merge` unless explicitly instructed by the user**
 -   **Always wait for user review and approval before any merge**
+-   Before you go through the commit -> push -> PR flow, run `gh auth status` to confirm the GitHub CLI is connected; use `gh auth login` if it is not.
 
 ### File Operations
 -   Never use `rm -rf` - use `rm -i` for interactive confirmation.


### PR DESCRIPTION
## Summary
- always export CODEX_HOME when the .codex directory is present
- remind agents to verify GitHub CLI auth before committing or pushing
- keep the packaged documentation in sync with the root instructions

## Testing
- [ ] Not run
