### PR TITLE
chore: stop shipping Claude prompts

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,7 +1,5 @@
-# Keep prompts and commands tracked; ignore other Claude artifacts
+# Keep command files tracked; ignore other Claude artifacts
 *
 !.gitignore
 !commands/
 !commands/**
-!prompts/
-!prompts/**

--- a/.claude/prompts/README.md
+++ b/.claude/prompts/README.md
@@ -1,4 +1,0 @@
-# Claude Prompts
-
-Shared prompt templates live here. The repository-level `.gitignore` keeps other
-Claude runtime state out of git while retaining this folder.

--- a/.codex/.gitignore
+++ b/.codex/.gitignore
@@ -1,0 +1,6 @@
+# Keep prompt templates tracked; ignore other Codex artifacts
+*
+!.gitignore
+!README.md
+!prompts/
+!prompts/**

--- a/.codex/prompts/README.md
+++ b/.codex/prompts/README.md
@@ -3,3 +3,7 @@
 Store shared Codex prompt templates here. The root `.gitignore` keeps the rest
 of the Codex CLI runtime state out of git while retaining this folder so the
 toolkit can rely on `CODEX_HOME` existing.
+
+Bundled starters:
+- `analysis.md` — structure discovery work before anyone starts coding.
+- `handoff.md` — capture progress and next steps when another agent takes over.

--- a/.codex/prompts/README.md
+++ b/.codex/prompts/README.md
@@ -1,5 +1,5 @@
-# Repository Codex Workspace
+# Codex Prompts
 
-This folder holds prompts and other data produced by the Codex CLI while you
-work inside this repo. It is intentionally committed so `.envrc` can point
-`CODEX_HOME` here without extra setup.
+Store shared Codex prompt templates here. The root `.gitignore` keeps the rest
+of the Codex CLI runtime state out of git while retaining this folder so the
+toolkit can rely on `CODEX_HOME` existing.

--- a/.codex/prompts/analysis.md
+++ b/.codex/prompts/analysis.md
@@ -1,0 +1,16 @@
+# Analysis Template
+
+Use this prompt when you need Codex to dig into a ticket or idea before coding.
+
+## Input Checklist
+- Problem statement or ticket link
+- Relevant code paths or files
+- Existing constraints, deadlines, or success metrics
+
+## What Codex Should Produce
+1. A concise summary of the task in plain language
+2. Key unknowns or risks that require clarification
+3. A ranked list of implementation options (with trade-offs)
+4. Suggested validation steps or tests once a solution ships
+
+Feel free to add extra context below this line before sending.

--- a/.codex/prompts/handoff.md
+++ b/.codex/prompts/handoff.md
@@ -1,0 +1,16 @@
+# Handoff Template
+
+Use this prompt when transferring partially completed work to another agent or teammate.
+
+## Include For The Recipient
+- Current status and remaining tasks
+- Links to branches, PRs, or specs
+- Outstanding decisions or questions
+- Repro steps for any bugs that remain
+
+## What Codex Should Return
+- A clean summary suitable for chat or PR description
+- A checklist of next actions with owners (if known)
+- Risks or blockers that need attention
+
+Document additional details below this line before you send the prompt.

--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,6 @@
 /.claude/*
 !.claude/commands/
 !.claude/commands/**
-!.claude/prompts/
-!.claude/prompts/**
 /.codex/*
 !.codex/prompts/
 !.codex/prompts/**

--- a/README.md
+++ b/README.md
@@ -98,17 +98,22 @@ agents/                    # Agent worktrees (fully gitignored)
 └── 3-agent/               # Worktree for agent 3
 
 .envrc                     # direnv hook adding script aliases and PATH entries; run `direnv allow` here and inside each agents/* worktree
-.claude/                   # Claude workspace shared by tracked commands and prompts
+.claude/                   # Claude workspace shared by tracked commands
 ├── commands/              # Custom slash commands for Claude
 │   ├── maw-agents-create.md     # Agent creation command (/maw-agents-create)
 │   ├── maw-codex.md            # Codex integration command (/maw-codex)
 │   ├── maw-codex.sh            # Shell helper backing the codex command
 │   ├── maw-sync.md             # Sync helper for main/agents worktrees (/maw-sync)
 │   └── maw-sync.sh             # Shell helper implementing sync rules
-└── prompts/               # Shared prompt templates (tracked)
 
 .agents/config/tmux.conf   # curated tmux config with TPM + power theme
 /.codex/                   # Codex CLI workspace; .envrc points CODEX_HOME here automatically
+├── .gitignore             # Ignore runtime state but keep prompt templates tracked
+├── README.md              # Explains how the Codex workspace is used
+└── prompts/               # Shared Codex prompt templates
+    ├── README.md
+    ├── analysis.md
+    └── handoff.md
 docs/                      # deep dives and checklists
 ```
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -27,8 +27,9 @@ Verify the following filesystem state inside the temporary repo:
 - `.envrc` exists and contains the helper sourcing block.
 - `.codex/README.md` exists and `CODEX_HOME` is set to that directory when
   `direnv` loads.
-- `.codex/prompts/` contains the tracked prompt templates while `.claude`
-  only includes the command definitions.
+- `.codex/prompts/` contains the tracked prompt templates (`README.md`,
+  `analysis.md`, `handoff.md`) while `.claude` only includes the command
+  definitions.
 - `.gitignore` includes the injected Multi-Agent Kit section and preserves
   Claude overrides.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -27,8 +27,8 @@ Verify the following filesystem state inside the temporary repo:
 - `.envrc` exists and contains the helper sourcing block.
 - `.codex/README.md` exists and `CODEX_HOME` is set to that directory when
   `direnv` loads.
-- `.claude/commands/` and `.claude/prompts/` are present (with README) while
-  other Claude files remain ignored.
+- `.codex/prompts/` contains the tracked prompt templates while `.claude`
+  only includes the command definitions.
 - `.gitignore` includes the injected Multi-Agent Kit section and preserves
   Claude overrides.
 

--- a/src/multi_agent_kit.egg-info/SOURCES.txt
+++ b/src/multi_agent_kit.egg-info/SOURCES.txt
@@ -34,6 +34,9 @@ src/multi_agent_kit/assets/.claude/commands/maw-codex.md
 src/multi_agent_kit/assets/.claude/commands/maw-codex.sh
 src/multi_agent_kit/assets/.claude/commands/maw-sync.md
 src/multi_agent_kit/assets/.claude/commands/maw-sync.sh
+src/multi_agent_kit/assets/.codex/.gitignore
 src/multi_agent_kit/assets/.codex/prompts/README.md
+src/multi_agent_kit/assets/.codex/prompts/analysis.md
+src/multi_agent_kit/assets/.codex/prompts/handoff.md
 src/multi_agent_kit/assets/.codex/README.md
 tests/test_install.py

--- a/src/multi_agent_kit.egg-info/SOURCES.txt
+++ b/src/multi_agent_kit.egg-info/SOURCES.txt
@@ -34,5 +34,6 @@ src/multi_agent_kit/assets/.claude/commands/maw-codex.md
 src/multi_agent_kit/assets/.claude/commands/maw-codex.sh
 src/multi_agent_kit/assets/.claude/commands/maw-sync.md
 src/multi_agent_kit/assets/.claude/commands/maw-sync.sh
+src/multi_agent_kit/assets/.codex/prompts/README.md
 src/multi_agent_kit/assets/.codex/README.md
 tests/test_install.py

--- a/src/multi_agent_kit/assets/.claude/.gitignore
+++ b/src/multi_agent_kit/assets/.claude/.gitignore
@@ -1,7 +1,5 @@
-# Keep prompts and commands tracked; ignore other Claude artifacts
+# Keep command files tracked; ignore other Claude artifacts
 *
 !.gitignore
 !commands/
 !commands/**
-!prompts/
-!prompts/**

--- a/src/multi_agent_kit/assets/.claude/prompts/README.md
+++ b/src/multi_agent_kit/assets/.claude/prompts/README.md
@@ -1,4 +1,0 @@
-# Claude Prompts
-
-Shared prompt templates live here. The toolkit tracks this directory but ignores
-other Claude runtime files.

--- a/src/multi_agent_kit/assets/.codex/.gitignore
+++ b/src/multi_agent_kit/assets/.codex/.gitignore
@@ -1,0 +1,6 @@
+# Keep prompt templates tracked; ignore other Codex artifacts
+*
+!.gitignore
+!README.md
+!prompts/
+!prompts/**

--- a/src/multi_agent_kit/assets/.codex/prompts/README.md
+++ b/src/multi_agent_kit/assets/.codex/prompts/README.md
@@ -1,3 +1,7 @@
 # Codex Prompts
 
 Store shared Codex prompt templates here. The root `.gitignore` keeps the rest of the Codex CLI runtime state out of git while retaining this folder so the toolkit can rely on `CODEX_HOME` existing.
+
+Bundled starters:
+- `analysis.md` — structure discovery work before anyone starts coding.
+- `handoff.md` — capture progress and next steps when another agent takes over.

--- a/src/multi_agent_kit/assets/.codex/prompts/README.md
+++ b/src/multi_agent_kit/assets/.codex/prompts/README.md
@@ -1,0 +1,3 @@
+# Codex Prompts
+
+Store shared Codex prompt templates here. The root `.gitignore` keeps the rest of the Codex CLI runtime state out of git while retaining this folder so the toolkit can rely on `CODEX_HOME` existing.

--- a/src/multi_agent_kit/assets/.codex/prompts/analysis.md
+++ b/src/multi_agent_kit/assets/.codex/prompts/analysis.md
@@ -1,0 +1,16 @@
+# Analysis Template
+
+Use this prompt when you need Codex to inspect a ticket or idea before anyone starts coding.
+
+## Input Checklist
+- Problem statement or ticket link
+- Relevant code paths or files
+- Constraints, deadlines, or success metrics
+
+## What Codex Should Produce
+1. A concise summary of the task in plain language
+2. Key unknowns or risks that require clarification
+3. A ranked list of implementation options (with trade-offs)
+4. Suggested validation steps or tests once a solution ships
+
+Add any extra context below this line before sending.

--- a/src/multi_agent_kit/assets/.codex/prompts/handoff.md
+++ b/src/multi_agent_kit/assets/.codex/prompts/handoff.md
@@ -1,0 +1,16 @@
+# Handoff Template
+
+Use this prompt when transferring partially completed work to another agent or teammate.
+
+## Include For The Recipient
+- Current status and remaining tasks
+- Links to branches, PRs, or specs
+- Outstanding decisions or questions
+- Repro steps for any bugs that remain
+
+## What Codex Should Return
+- A clean summary suitable for chat or PR description
+- A checklist of next actions with owners (if known)
+- Risks or blockers that need attention
+
+Capture any additional notes below this line before sending.

--- a/src/multi_agent_kit/install.py
+++ b/src/multi_agent_kit/install.py
@@ -81,8 +81,9 @@ class AssetInstaller:
             "/.claude/*",
             "!.claude/commands/",
             "!.claude/commands/**",
-            "!.claude/prompts/",
-            "!.claude/prompts/**",
+            "/.codex/*",
+            "!.codex/prompts/",
+            "!.codex/prompts/**",
         ]
 
         try:


### PR DESCRIPTION
## Summary
- drop the tracked .claude/prompts directory from the assets bundle
- move the prompt README into .codex/prompts so codex holds the shared templates
- update installer gitignore entries and docs to match the new layout

## Testing
- uvx --from . multi-agent-kit --help
- tmpdir smoke init via uvx --from /Users/nat/Code/github.com/laris-co/multi-agent-workflow-kit multi-agent-kit init --prefix verify-prompts (ensured .claude has only commands)
