### PR TITLE
Shorten branching strategy TL;DR

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ Session names follow `ai-<repo-name>` by default. Provide `--prefix sprint` to s
 - `docs/architecture.md` — architecture, strengths, risks, and integration ideas.
 - `docs/operations-checklist.md` — launch/teardown guardrails for reliable runs.
 - `docs/testing.md` — smoke-test routine before shipping updates or releases.
+- `docs/branching-strategy.md` — guidance on using `development` for staging and
+  `main` for production.
 
 ## Extending the Kit
 - Pair the toolkit with your governance/constitution doc so agents share common rules.

--- a/docs/branching-strategy.md
+++ b/docs/branching-strategy.md
@@ -1,0 +1,29 @@
+# Branching Strategy TL;DR
+
+Keep production (`main`) pristine and route every change through the staging
+branch (`development`). The bullets below capture the entire flow.
+
+## Core Branches
+- `main`: production-only, locked behind reviews + CI.
+- `development`: staging/integration; only source for pull requests into `main`.
+
+## Daily Work
+1. Branch from `development` for features or fixes.
+2. Rebase/merge from `development` often so releases stay smooth.
+3. Open a pull request back into `development`; require checks + review.
+
+## Release Rhythm
+- Deploy and test from `development` until the build is stable.
+- Cut a release PR **from `development` to `main`**; nothing else merges to
+  `main`.
+- Tag the commit on `main` after the release PR lands.
+
+## Hotfixes (Still Flow Through `development`)
+- Branch from `main` to ship the urgent fix.
+- Once verified, merge that branch into `development` and run the same checks.
+- Promote `development` back into `main` so production and staging match.
+
+## Guardrails
+- Protect both branches from direct pushes.
+- Require release PRs into `main` to originate from `development`.
+- Document this short flow in onboarding material so everyone follows it.


### PR DESCRIPTION
## Summary
- replace the branching strategy guide with a concise TL;DR that keeps the development-first workflow clear

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e4b90d3a408328984e8fc4020c658f