### PR TITLE
feat: support simplified agent naming (1, 2, 3 instead of 1-agent, 2-agent)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ Each agent operates in a **worktree**—a separate directory linked to a unique 
 ```
 repo/                  ← main worktree (branch: main)
 agents/
-  ├── 1-agent/        ← worktree (branch: agents/1-agent)
-  ├── 2-agent/        ← worktree (branch: agents/2-agent)
-  └── 3-agent/        ← worktree (branch: agents/3-agent)
+  ├── 1/              ← worktree (branch: agents/1)
+  ├── 2/              ← worktree (branch: agents/2)
+  └── 3/              ← worktree (branch: agents/3)
 ```
 
 ### Tmux Layouts
@@ -94,15 +94,15 @@ Edit `.agents/agents.yaml` to define agents:
 
 ```yaml
 agents:
-  1-agent:
-    branch: agents/1-agent
-    worktree_path: agents/1-agent
+  1:
+    branch: agents/1
+    worktree_path: agents/1
     model: sonnet
     description: "Backend API development"
 
-  2-agent:
-    branch: agents/2-agent
-    worktree_path: agents/2-agent
+  2:
+    branch: agents/2
+    worktree_path: agents/2
     model: opus
     description: "Frontend React components"
 ```
@@ -159,8 +159,8 @@ maw start profile0
 direnv allow
 
 # In each agent worktree
-cd agents/1-agent && direnv allow
-cd agents/2-agent && direnv allow
+cd agents/1 && direnv allow
+cd agents/2 && direnv allow
 ```
 
 This activates the `maw` command wrapper and sets `CODEX_HOME` for shared state.
@@ -184,10 +184,10 @@ maw kill
 
 ```bash
 # Navigate to agent worktree
-cd agents/1-agent
+cd agents/1
 
 # Check agent's branch
-git branch --show-current  # → agents/1-agent
+git branch --show-current  # → agents/1
 
 # Make changes, commit
 git add .
@@ -209,7 +209,7 @@ cd /path/to/main
 maw sync  # pulls from origin
 
 # From agent worktree
-cd agents/1-agent
+cd agents/1
 maw sync  # merges local main
 ```
 
@@ -231,10 +231,10 @@ maw send "git pull"
 maw agents list
 
 # Create new agent
-maw agents create 4-agent -m claude-opus
+maw agents create 4 -m claude-opus
 
 # Remove agent worktree
-maw remove 3-agent
+maw remove 3
 ```
 
 ## Configuration
@@ -243,9 +243,9 @@ maw remove 3-agent
 
 ```yaml
 agents:
-  1-agent:
-    branch: agents/1-agent          # Git branch name
-    worktree_path: agents/1-agent   # Directory under agents/
+  1:
+    branch: agents/1                # Git branch name
+    worktree_path: agents/1         # Directory under agents/
     model: claude-sonnet-4          # Model identifier (informational)
     description: "Core backend"     # Purpose (optional)
 ```
@@ -303,9 +303,9 @@ maw start profile0  # → research-<repo-name>
 
 agents/                      # Agent worktrees (gitignored)
 ├── .gitignore               # Ignores all contents
-├── 1-agent/                 # Worktree for agent 1
-├── 2-agent/                 # Worktree for agent 2
-└── 3-agent/                 # Worktree for agent 3
+├── 1/                       # Worktree for agent 1
+├── 2/                       # Worktree for agent 2
+└── 3/                       # Worktree for agent 3
 
 .envrc                       # Direnv config (maw helpers, CODEX_HOME)
 .codex/                      # Codex CLI workspace (shared across worktrees)
@@ -340,7 +340,7 @@ maw warp <target>    # Navigate to agent worktree or root
 maw start profile1 --prefix hackathon
 
 # Navigate to agent worktree
-maw warp 2-agent
+maw warp 2
 
 # Return to main
 maw warp root
@@ -444,7 +444,7 @@ tmux kill-session -t ai-repo-name
 git worktree list
 
 # Remove stale worktree
-git worktree remove agents/1-agent --force
+git worktree remove agents/1 --force
 
 # Prune stale references
 git worktree prune
@@ -460,8 +460,8 @@ maw install
 direnv allow
 
 # Allow in each agent worktree
-cd agents/1-agent && direnv allow
-cd agents/2-agent && direnv allow
+cd agents/1 && direnv allow
+cd agents/2 && direnv allow
 
 # Check if direnv is working
 direnv status
@@ -486,7 +486,7 @@ source .envrc
 ### Merge Conflicts in Agent Worktrees
 
 ```bash
-cd agents/1-agent
+cd agents/1
 
 # Sync with main
 git fetch origin main:main  # update local main

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,13 +8,13 @@ The multi-agent workflow combines git worktrees with tmux so that each agent rec
 Main repository (.git)
     ├── source files
     └── agents/
-          ├── 1-agent/ (worktree → branch agents/1-agent)
-          ├── 2-agent/ (worktree → branch agents/2-agent)
-          └── 3-agent/ (worktree → branch agents/3-agent)
+          ├── 1/ (worktree → branch agents/1)
+          ├── 2/ (worktree → branch agents/2)
+          └── 3/ (worktree → branch agents/3)
 
 .tmux session
-    ├── pane: agent 1 shell (cd agents/1-agent)
-    ├── pane: agent 2 shell (cd agents/2-agent)
+    ├── pane: agent 1 shell (cd agents/1)
+    ├── pane: agent 2 shell (cd agents/2)
     └── pane: shared tools / orchestration
 ```
 

--- a/src/multi_agent_kit/assets/.agents/agents.yaml
+++ b/src/multi_agent_kit/assets/.agents/agents.yaml
@@ -1,18 +1,23 @@
 # Define each agent's branch and worktree location here.
 # Copy this file to match your team structure; run `.agents/setup.sh` afterward.
+#
+# Agent naming is flexible - use any pattern that works for your workflow:
+#   - Simplified: 1, 2, 3 (recommended for quick setup)
+#   - Descriptive: backend-api, frontend-ui, data-processor
+#   - Legacy: 1-agent, 2-agent, 3-agent (still supported)
 agents:
-  1-agent:
-    branch: agents/1-agent
-    worktree_path: agents/1-agent
+  1:
+    branch: agents/1
+    worktree_path: agents/1
     model: default
     description: Primary agent workspace
-  2-agent:
-    branch: agents/2-agent
-    worktree_path: agents/2-agent
+  2:
+    branch: agents/2
+    worktree_path: agents/2
     model: default
     description: Secondary agent workspace
-  3-agent:
-    branch: agents/3-agent
-    worktree_path: agents/3-agent
+  3:
+    branch: agents/3
+    worktree_path: agents/3
     model: default
     description: Tertiary agent workspace


### PR DESCRIPTION
## Summary

Implements simplified agent naming pattern as planned in #74. Changes default configuration from verbose `1-agent`, `2-agent`, `3-agent` to clean `1`, `2`, `3`.

**Key Discovery**: No code changes needed! The toolkit scripts are already naming-agnostic.

## Changes Made

### 1. Default Configuration Update
**File**: `src/multi_agent_kit/assets/.agents/agents.yaml`
- Changed default agent names from `1-agent` → `1`, `2-agent` → `2`, `3-agent` → `3`
- Updated all branches and worktree paths to match
- Added documentation comment showing naming flexibility:
  - Simplified: `1`, `2`, `3` (recommended)
  - Descriptive: `backend-api`, `frontend-ui`
  - Legacy: `1-agent`, `2-agent` (still supported)

### 2. Documentation Updates
**README.md** - Updated all examples:
- Core Concepts worktree diagram
- Agent configuration examples
- Daily workflow commands
- Configuration examples
- Repository layout
- maw command examples
- Troubleshooting examples

**docs/architecture.md** - Updated:
- System architecture diagram
- Worktree structure visualization

## Benefits

✅ **Cleaner paths**: `agents/1` vs `agents/1-agent`  
✅ **Faster typing**: Shorter names for `cd agents/1`  
✅ **Better UX**: Cleaner autocomplete (`maw warp <tab>` shows: `1  2  3  root`)  
✅ **Flexibility**: Users can choose any naming pattern  
✅ **Backward compatible**: Old naming continues to work  

## Technical Verification

### Scripts Already Support This
- ✅ `start-agents.sh` - Uses directory discovery (line 62)
- ✅ `agents.sh` - Reads from agents.yaml, doesn't enforce naming
- ✅ All profile scripts - Work with any directory name

### Autocomplete Verified
Both completion systems use dynamic directory scanning:
- ✅ `maw-completion.zsh` - Scans `agents/` directory at runtime
- ✅ `maw-completion.bash` - Scans `agents/` directory at runtime
- ✅ No hardcoded patterns anywhere

See verification: https://github.com/laris-co/multi-agent-workflow-kit/issues/74#issuecomment-3379216225

### Testing
```bash
# Verified YAML parsing with numeric keys
$ yq '.agents.1.branch' test-agents.yaml
agents/1

# Autocomplete will show:
$ maw warp <tab>
1  2  3  root
```

## Files Modified
- `src/multi_agent_kit/assets/.agents/agents.yaml` - Default config
- `README.md` - All examples and documentation
- `docs/architecture.md` - System diagrams

## Migration Guide

### For New Users
Just use the new default configuration (already done).

### For Existing Users
Optional - keep using current naming or migrate:

```yaml
# Old (still works)
agents:
  1-agent:
    branch: agents/1-agent
    worktree_path: agents/1-agent

# New (cleaner)
agents:
  1:
    branch: agents/1
    worktree_path: agents/1
```

## Success Criteria

- [x] Default agents.yaml uses simplified naming
- [x] README shows simplified naming in all examples
- [x] Both naming patterns documented as supported
- [x] YAML parsing tested with numeric keys
- [x] Autocomplete verified to work with any naming
- [x] No breaking changes to existing setups

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>