### PR TITLE
feat: Add generic maw-hey command for inter-agent communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ maw start <profile>  # Launch tmux session
 maw attach           # Attach to running session
 maw agents <cmd>     # Manage worktrees (list, create, remove)
 maw send "<cmd>"     # Broadcast command to all panes
+maw hey <agent> <msg> # Send message to specific agent
 maw kill             # Terminate session
 maw remove <agent>   # Delete agent worktree
 maw uninstall        # Remove toolkit from repo
@@ -341,6 +342,11 @@ maw start profile1 --prefix hackathon
 
 # Navigate to agent worktree
 maw warp 2
+
+# Send message to specific agent
+maw hey 1 "analyse this codebase"
+maw hey 2 "create a plan for feature X"
+maw hey root "git status"
 
 # Return to main
 maw warp root
@@ -357,10 +363,24 @@ When working in Claude Code, use these custom commands:
 ### `/maw-sync`
 Sync current worktree with main branch (context-aware).
 
-### `/maw-codex` (if configured)
-Send prompt to codex agent pane in tmux.
+### `/maw-hey`
+Send a message to a specific agent in the tmux session.
 
-Example: `/maw-codex explain the authentication flow`
+**Examples:**
+```bash
+/maw-hey 1 analyse this repository structure
+/maw-hey 2 create a plan for the auth feature
+/maw-hey root git status
+/maw-hey all git pull  # broadcast to all agents
+```
+
+**Special targets:**
+- `root` - Main worktree pane
+- `all` - Broadcast to all agent panes
+- Agent names: `1`, `2`, `backend-api`, etc.
+
+### `/maw-codex` (legacy)
+Send prompt to agent in pane 1. **Note:** Use `/maw-hey 1 <message>` for more flexibility.
 
 ## Advanced Usage
 

--- a/src/multi_agent_kit/assets/.agents/maw-completion.bash
+++ b/src/multi_agent_kit/assets/.agents/maw-completion.bash
@@ -5,7 +5,7 @@ _maw_complete() {
   local cur prev words cword
   _init_completion || return
 
-  local subcommands="install setup start agents kill send remove uninstall warp help"
+  local subcommands="install setup start agents kill send remove uninstall warp hey help"
 
   if [[ $cword -eq 1 ]]; then
     # Complete main subcommands
@@ -16,6 +16,20 @@ _maw_complete() {
   local subcommand="${words[1]}"
 
   case "$subcommand" in
+    hey)
+      # Complete agent names + special targets
+      if [[ $cword -eq 2 ]]; then
+        local agents_dir="${MAW_REPO_ROOT:-$PWD}/agents"
+        local targets="root all"
+        if [[ -d "$agents_dir" ]]; then
+          local agent_dirs
+          agent_dirs=$(ls -1 "$agents_dir" 2>/dev/null | grep -v '^\.')
+          targets="$targets $agent_dirs"
+        fi
+        COMPREPLY=($(compgen -W "$targets" -- "$cur"))
+      fi
+      return 0
+      ;;
     warp)
       # Complete agent names + "root"
       local agents_dir="${MAW_REPO_ROOT:-$PWD}/agents"

--- a/src/multi_agent_kit/assets/.agents/maw-completion.zsh
+++ b/src/multi_agent_kit/assets/.agents/maw-completion.zsh
@@ -16,6 +16,7 @@ _maw() {
     'remove:Run remove.sh to delete agent worktrees'
     'uninstall:Run uninstall.sh to remove toolkit assets'
     'warp:Navigate to agent worktree or root'
+    'hey:Send a message to a specific agent'
     'help:Show help message'
   )
 
@@ -29,6 +30,25 @@ _maw() {
       ;;
     args)
       case "${words[1]}" in
+        hey)
+          if [[ $CURRENT -eq 3 ]]; then
+            # Complete agent names and special targets
+            local agents_dir="${MAW_REPO_ROOT:-$PWD}/agents"
+            local -a targets
+            targets=('root:Main worktree pane' 'all:Broadcast to all agents')
+
+            if [[ -d "$agents_dir" ]]; then
+              local dir
+              for dir in "$agents_dir"/*(N/); do
+                local basename="${dir:t}"
+                [[ "$basename" == .* ]] && continue
+                targets+=("$basename:Agent worktree")
+              done
+            fi
+
+            _describe -t targets 'agent' targets
+          fi
+          ;;
         warp)
           local agents_dir="${MAW_REPO_ROOT:-$PWD}/agents"
           local -a agent_dirs

--- a/src/multi_agent_kit/assets/.agents/maw-env.sh
+++ b/src/multi_agent_kit/assets/.agents/maw-env.sh
@@ -47,7 +47,8 @@ Commands:
   send               Run send-commands.sh to broadcast commands to panes
   remove             Run remove.sh to delete agent worktrees
   uninstall          Run uninstall.sh to remove toolkit assets
-  warp <target>      Navigate to agent worktree or root (e.g., warp 1-agent, warp root)
+  warp <target>      Navigate to agent worktree or root (e.g., warp 1, warp root)
+  hey <agent> <msg>  Send a message to a specific agent (e.g., hey 1 analyse repo)
 USAGE
 }
 
@@ -154,6 +155,9 @@ maw() {
     warp)
       __maw_warp "$@"
       ;;
+    hey)
+      __maw_exec hey.sh "$@"
+      ;;
     help|-h|--help)
       __maw_usage
       ;;
@@ -173,6 +177,7 @@ alias maw-kill='maw kill'
 alias maw-send='maw send'
 alias maw-remove='maw remove'
 alias maw-uninstall='maw uninstall'
+alias maw-hey='maw hey'
 
 # Load shell completion if available
 if [[ -n "${ZSH_VERSION:-}" ]]; then

--- a/src/multi_agent_kit/assets/.agents/scripts/hey.sh
+++ b/src/multi_agent_kit/assets/.agents/scripts/hey.sh
@@ -1,0 +1,216 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+AGENT_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+REPO_ROOT=$(cd "$AGENT_ROOT/.." && pwd)
+
+show_usage() {
+    cat <<'USAGE'
+Usage: hey.sh <agent> <message>
+       hey.sh --list
+       hey.sh --map
+
+Send a message to a specific agent in the tmux session.
+
+Arguments:
+  <agent>     Agent name (e.g., 1, 2, backend-api) or special target (root, all)
+  <message>   Message to send to the agent
+
+Options:
+  --list      List available agents
+  --map       Show agent to pane mapping
+
+Examples:
+  hey.sh 1 "analyse this repository"
+  hey.sh 2 "create a plan for auth feature"
+  hey.sh root "git status"
+  hey.sh all "git pull"
+USAGE
+}
+
+list_agents() {
+    local agents_dir="$REPO_ROOT/agents"
+
+    echo "📋 Available agents:"
+    if [[ -d "$agents_dir" ]]; then
+        local agents=($(cd "$agents_dir" && ls -d */ 2>/dev/null | sed 's#/##'))
+        if [[ ${#agents[@]} -gt 0 ]]; then
+            for agent in "${agents[@]}"; do
+                echo "  - $agent"
+            done
+        else
+            echo "  (no agents found)"
+        fi
+    else
+        echo "  (agents directory not found)"
+    fi
+    echo ""
+    echo "Special targets:"
+    echo "  - root  (main worktree pane)"
+    echo "  - all   (broadcast to all agents)"
+}
+
+show_map() {
+    local agents_dir="$REPO_ROOT/agents"
+    local agents=($(cd "$agents_dir" && ls -d */ 2>/dev/null | sed 's#/##'))
+
+    echo "📊 Agent to pane mapping:"
+    for i in "${!agents[@]}"; do
+        echo "  Agent '${agents[$i]}' → pane $i (agents/${agents[$i]})"
+    done
+
+    # Try to find root pane
+    if [[ -n "${SESSION_NAME:-}" ]] && [[ -n "${WINDOW_INDEX:-}" ]]; then
+        local root_pane=$(tmux list-panes -t "$SESSION_NAME:$WINDOW_INDEX" -F "#{pane_index} #{pane_current_path}" 2>/dev/null | \
+            grep "$REPO_ROOT\$" | cut -d' ' -f1 || echo "unknown")
+        echo "  Root           → pane $root_pane (main worktree)"
+    else
+        echo "  Root           → (session not detected)"
+    fi
+}
+
+# Parse arguments
+if [[ $# -eq 0 ]]; then
+    show_usage
+    exit 1
+fi
+
+case "$1" in
+    --list|-l)
+        list_agents
+        exit 0
+        ;;
+    --map|-m)
+        show_map
+        exit 0
+        ;;
+    --help|-h)
+        show_usage
+        exit 0
+        ;;
+esac
+
+AGENT_TARGET=$1
+shift
+MESSAGE="$*"
+
+if [[ -z "$MESSAGE" ]]; then
+    echo "❌ Error: No message provided"
+    echo ""
+    show_usage
+    exit 1
+fi
+
+# Find tmux session
+DIR_NAME=$(basename "$REPO_ROOT")
+BASE_PREFIX=${SESSION_PREFIX:-ai}
+SESSION_NAME=""
+
+# Try exact match first
+if tmux has-session -t "${BASE_PREFIX}-${DIR_NAME}" 2>/dev/null; then
+    SESSION_NAME="${BASE_PREFIX}-${DIR_NAME}"
+else
+    # Look for sessions with custom suffix
+    MATCHING_SESSIONS=$(tmux list-sessions -F "#{session_name}" 2>/dev/null | grep "^${BASE_PREFIX}-${DIR_NAME}" || true)
+    SESSION_COUNT=$(echo "$MATCHING_SESSIONS" | grep -c . || echo 0)
+
+    if [[ $SESSION_COUNT -eq 1 ]]; then
+        SESSION_NAME="$MATCHING_SESSIONS"
+    elif [[ $SESSION_COUNT -gt 1 ]]; then
+        echo "❌ Error: Multiple matching sessions found:"
+        echo "$MATCHING_SESSIONS" | sed 's/^/  - /'
+        echo ""
+        echo "Please specify which session by setting SESSION_PREFIX"
+        exit 1
+    fi
+fi
+
+if [[ -z "$SESSION_NAME" ]]; then
+    echo "❌ Error: No tmux session found matching '${BASE_PREFIX}-${DIR_NAME}*'"
+    echo ""
+    echo "Expected session name patterns:"
+    echo "  - ${BASE_PREFIX}-${DIR_NAME}"
+    echo "  - ${BASE_PREFIX}-${DIR_NAME}-<suffix>"
+    echo ""
+    echo "Make sure the tmux session is running (use 'maw start')"
+    exit 1
+fi
+
+WINDOW_INDEX=$(tmux list-windows -t "$SESSION_NAME" -F "#{window_index}" | head -1)
+PANE_BASE=$(tmux show-options -gv pane-base-index 2>/dev/null || echo 0)
+
+# Handle special targets
+if [[ "$AGENT_TARGET" == "all" ]]; then
+    echo "📢 Broadcasting to all agents: $MESSAGE"
+    PANE_COUNT=$(tmux list-panes -t "$SESSION_NAME:$WINDOW_INDEX" -F "#{pane_index}" | wc -l)
+
+    for ((i=0; i<PANE_COUNT; i++)); do
+        PANE_INDEX=$((PANE_BASE + i))
+        TARGET_PANE="$SESSION_NAME:$WINDOW_INDEX.$PANE_INDEX"
+
+        # Skip root pane (usually the last one)
+        PANE_PATH=$(tmux display-message -t "$TARGET_PANE" -p "#{pane_current_path}" 2>/dev/null || echo "")
+        if [[ "$PANE_PATH" == "$REPO_ROOT" ]]; then
+            continue
+        fi
+
+        tmux send-keys -t "$TARGET_PANE" "$MESSAGE" Enter
+    done
+
+    echo "✅ Broadcasted to all agent panes"
+    exit 0
+fi
+
+if [[ "$AGENT_TARGET" == "root" ]] || [[ "$AGENT_TARGET" == "main" ]]; then
+    # Find root pane by matching current path
+    ROOT_PANE=$(tmux list-panes -t "$SESSION_NAME:$WINDOW_INDEX" -F "#{pane_index} #{pane_current_path}" 2>/dev/null | \
+        grep "$REPO_ROOT\$" | cut -d' ' -f1 || echo "")
+
+    if [[ -z "$ROOT_PANE" ]]; then
+        echo "❌ Error: Could not find root pane"
+        exit 1
+    fi
+
+    TARGET_PANE="$SESSION_NAME:$WINDOW_INDEX.$ROOT_PANE"
+    echo "📤 Sending to root pane: $MESSAGE"
+    tmux send-keys -t "$TARGET_PANE" "$MESSAGE" Enter
+    echo "✅ Sent successfully"
+    exit 0
+fi
+
+# Find agent by name
+AGENTS_DIR="$REPO_ROOT/agents"
+if [[ ! -d "$AGENTS_DIR" ]]; then
+    echo "❌ Error: Agents directory not found: $AGENTS_DIR"
+    exit 1
+fi
+
+AGENTS=($(cd "$AGENTS_DIR" && ls -d */ 2>/dev/null | sed 's#/##'))
+
+# Find agent index
+PANE_INDEX=""
+for i in "${!AGENTS[@]}"; do
+    if [[ "${AGENTS[$i]}" == "$AGENT_TARGET" ]]; then
+        PANE_INDEX=$((PANE_BASE + i))
+        break
+    fi
+done
+
+if [[ -z "$PANE_INDEX" ]]; then
+    echo "❌ Error: Agent '$AGENT_TARGET' not found"
+    echo ""
+    echo "Available agents:"
+    for agent in "${AGENTS[@]}"; do
+        echo "  - $agent"
+    done
+    echo ""
+    echo "Special targets: root, all"
+    exit 1
+fi
+
+TARGET_PANE="$SESSION_NAME:$WINDOW_INDEX.$PANE_INDEX"
+
+echo "📤 Sending to agent '$AGENT_TARGET' (pane $PANE_INDEX): $MESSAGE"
+tmux send-keys -t "$TARGET_PANE" "$MESSAGE" Enter
+echo "✅ Sent successfully"

--- a/src/multi_agent_kit/assets/.claude/commands/maw-hey.md
+++ b/src/multi_agent_kit/assets/.claude/commands/maw-hey.md
@@ -1,0 +1,44 @@
+---
+description: Send a message to a specific agent in the tmux session
+argument-hint: <agent> <message>
+allowed-tools:
+  - Bash(.claude/commands/maw-hey.sh:*)
+---
+
+Goal: Send a prompt to a specific agent running in a tmux pane.
+
+Inputs:
+- $1 → Agent name (e.g., 1, 2, backend-api) or special target (root, all)
+- $* → The message to send (all remaining arguments)
+
+Behavior:
+1) Discover available agents from agents/ directory
+2) Map agent name to correct tmux pane
+3) Send message to target pane and press Enter
+
+Shell template:
+
+```bash
+.claude/commands/maw-hey.sh "$@"
+```
+
+Usage examples:
+- `/maw-hey 1 analyse this repository structure`
+- `/maw-hey 2 create a plan for the auth feature`
+- `/maw-hey backend-api review the database schema`
+- `/maw-hey root git status`
+- `/maw-hey all git pull`
+
+Special targets:
+- **root** - Send to main worktree pane
+- **all** - Broadcast to all agent panes (excludes root)
+
+List agents:
+- `/maw-hey --list` - Show available agents
+- `/maw-hey --map` - Show agent to pane mapping
+
+Notes:
+- Requires tmux session to be running (use `maw start` to create it).
+- Automatically detects sessions with custom prefixes.
+- Works with any agent naming convention (1, 2, backend-api, etc.).
+- Set SESSION_PREFIX environment variable if using a non-default base prefix.

--- a/src/multi_agent_kit/assets/.claude/commands/maw-hey.sh
+++ b/src/multi_agent_kit/assets/.claude/commands/maw-hey.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+
+# Wrapper script for Claude slash command /maw-hey
+# Calls the core hey.sh implementation
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+AGENT_ROOT="$SCRIPT_DIR/../../.agents"
+HEY_SCRIPT="$AGENT_ROOT/scripts/hey.sh"
+
+if [[ ! -f "$HEY_SCRIPT" ]]; then
+    echo "❌ Error: hey.sh script not found at $HEY_SCRIPT"
+    exit 1
+fi
+
+exec "$HEY_SCRIPT" "$@"

--- a/src/multi_agent_kit/assets/.envrc
+++ b/src/multi_agent_kit/assets/.envrc
@@ -66,7 +66,8 @@ Commands:
   send               Run send-commands.sh to broadcast commands to panes
   remove             Run remove.sh to delete agent worktrees
   uninstall          Run uninstall.sh to remove toolkit assets
-  warp <target>      Navigate to agent worktree or root (e.g., warp 1-agent, warp root)
+  warp <target>      Navigate to agent worktree or root (e.g., warp 1, warp root)
+  hey <agent> <msg>  Send a message to a specific agent (e.g., hey 1 analyse repo)
 USAGE
     }
 
@@ -173,6 +174,9 @@ USAGE
         warp)
           __maw_warp "$@"
           ;;
+        hey)
+          __maw_exec hey.sh "$@"
+          ;;
         help|-h|--help)
           __maw_usage
           ;;
@@ -192,6 +196,7 @@ USAGE
     alias maw-send='maw send'
     alias maw-remove='maw remove'
     alias maw-uninstall='maw uninstall'
+    alias maw-hey='maw hey'
 
     # Load shell completion if available
     if [[ -n "${ZSH_VERSION:-}" ]]; then


### PR DESCRIPTION
## Summary
- Implements generic `maw-hey` command for sending messages to any agent
- Replaces hardcoded `/maw-codex` with flexible agent targeting
- Supports simplified agent naming (1, 2, 3) and descriptive names (backend-api, etc.)
- ✅ Verified uvx package distribution includes all new files

## Implementation
**Core messenger**: `.agents/scripts/hey.sh` (217 lines)
- Dynamic agent discovery from `agents/` directory
- Automatic pane index mapping: `PANE_INDEX = PANE_BASE + agent_array_index`
- Special targets: `root` (main pane), `all` (broadcast)
- Utilities: `--list` (show agents), `--map` (show pane mapping)

**Claude slash command**: `/maw-hey`
- Command definition: `.claude/commands/maw-hey.md`
- Wrapper script: `.claude/commands/maw-hey.sh`

**Shell integration**: `maw hey` command
- Added to `.envrc` and `maw-env.sh`
- Bash/Zsh completion with agent name suggestions
- Alias: `maw-hey`

## Usage Examples
```bash
# Shell commands
maw hey 1 "analyse this repository structure"
maw hey 2 "create a plan for the auth feature"
maw hey root "git status"
maw hey all "git pull"

# Claude slash commands
/maw-hey 1 analyse this repository structure
/maw-hey 2 create a plan for the auth feature
/maw-hey root git status
/maw-hey all git pull
```

## Package Verification
Confirmed all new files are included in wheel distribution:
- `multi_agent_kit/assets/.agents/scripts/hey.sh` ✅
- `multi_agent_kit/assets/.claude/commands/maw-hey.md` ✅
- `multi_agent_kit/assets/.claude/commands/maw-hey.sh` ✅

Package configuration in `pyproject.toml` correctly includes:
- `assets/.agents/**` (covers hey.sh)
- `assets/.claude/**` (covers maw-hey command files)

## Related Issues
- Closes #77 (maw-hey implementation plan)
- Context: #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)